### PR TITLE
Use default team when filtering changes by team

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,20 @@ this check.
 
 It will suggest files that need to be added or removed to the codeowners file. 
 
-### Changes
+### Filtering Changes in Pull Requests
 
 If you have a Pull Request to review and you just want to check the changes that
 make sense for your team, you can also filter the changes:
 
-    $  code-ownership-checker changes all
+    $  code-ownership-checker filter all
 
-It will use the default team file or you can pass the team as a parameter:
+It will use the default team file if you omit parameters:
 
-    $  code-ownership-checker changes by_team bootcamp
+    $  code-ownership-checker filter
+
+Or you can filter any team as a parameter:
+
+    $  code-ownership-checker filter by <owner>
 
 ## Development
 

--- a/lib/code/ownership/cli.rb
+++ b/lib/code/ownership/cli.rb
@@ -3,89 +3,14 @@
 require 'thor'
 require 'fuzzy_match'
 require_relative 'checker'
+require_relative 'filter'
+require_relative 'cli_base'
 
 # frozen_string_literal: true
 module Code
   module Ownership
-    class ChangesByOwner < Thor
-      option :from, default: 'origin/master'
-      option :to, default: 'HEAD'
-      option :verbose, default: false, type: :boolean, aliases: '-v'
-      desc 'by_team [TEAM]', 'Lists changed files owned by TEAM. If no team is specified, default team is taken from .default_team'
-      # option :local, default: false, type: :boolean, aliases: '-l'
-      # option :branch, default: '', aliases: '-b'
-      def by_team(team_name = nil)
-        team_name ||= default_team
-
-        unless team_name
-          puts 'Please provide a team name or configure a default team.',
-          "Try `#{$PROGRAM_NAME} --team <team-name>` to configure the team."
-          return
-        end
-
-        changes = checker.changes_with_ownership(team_name)
-        if changes.key?(team_name)
-          changes.values.each { |file| puts file }
-        else
-          puts "Owner #{team_name} not defined in .github/CODEOWNERS"
-        end
-      end
-
-      option :from, default: 'origin/master'
-      option :to, default: 'HEAD'
-      option :verbose, default: false, type: :boolean, aliases: '-v'
-      desc 'by_team USER', 'Lists changed files owned by USER'
-      def by_user(user)
-        checker.changes_with_ownership { |rec| rec.owners.find { |owner| owner == '@' + user } }.each do |rec|
-          puts rec.owner + ":\n  " + rec.changes.join("\n  ") + "\n\n"
-        end
-      end
-
-      option :from, default: 'origin/master'
-      option :to, default: 'HEAD'
-      option :verbose, default: false, type: :boolean, aliases: '-v'
-      desc 'all', 'Lists all changed files grouped by owner'
-      def all
-        changes = checker.changes_with_ownership.select { |_owner, val| val && !val.empty? }
-        changes.keys.each do |owner|
-          puts(owner + ":\n  " + changes[owner].join("\n  ") + "\n\n")
-        end
-      end
-
-      def initialize(args = [], options = {}, config = {})
-        super
-        @repo_base_path = `git rev-parse --show-toplevel`
-        @default_team_file = @repo_base_path.chomp + '/.default_team'
-        if !@repo_base_path || @repo_base_path.empty?
-          raise 'You must be positioned in a git repository to use this tool'
-        end
-
-        @repo_base_path.chomp!
-        Dir.chdir(@repo_base_path)
-      end
-
-      private
-
-      def checker
-        @checker ||= Code::Ownership::Checker.new(@repo_base_path, options[:from], options[:to])
-      end
-
-      def default_team
-        return unless File.exist?(@default_team_file)
-
-        IO.read(@default_team_file).chomp
-      end
-    end
-
     # Command Line Interface used by bin/code-owners-checker.
-    class CLI < Thor
-      attr_reader :default_team_file
-      def initialize(*args)
-        super
-        @repo_base_path = `git rev-parse --show-toplevel`.chomp
-        @default_team_file = @repo_base_path + '/.default_team'
-      end
-
+    class CLI < CLIBase
       LABEL = { missing_ref: 'Missing references', useless_pattern: 'No files matching with the pattern' }.freeze
       option :from, default: 'origin/master'
       option :to, default: 'HEAD'
@@ -93,25 +18,13 @@ module Code
       desc 'check REPO', 'Checks .github/CODEOWNERS consistency'
       def check(repo = '.')
         @repo = repo
-        @checker = Code::Ownership::Checker.new(@repo, options[:from], options[:to])
-        @checker.when_useless_pattern do |record|
-          suggest_fix_for record
-        end
-
-        @checker.when_new_file do |file|
-          suggest_add_to_codeowners file
-        end
-
-        @checker.when_deleted_file do |file|
-          suggest_remove_from_codeowners file
-        end
-
+        setup_checker
         @checker.check!
         @checker.commit_changes! if options[:interactive] && yes?('Commit changes?')
       end
 
-      desc 'changes SUBCOMMAND', 'List owners of changed files'
-      subcommand 'changes', Code::Ownership::ChangesByOwner
+      desc 'filter <by-owner>', 'List owners of changed files'
+      subcommand 'filter', Code::Ownership::Filter
 
       desc 'config', 'Checks config is consistent or configure it'
       option :team
@@ -119,34 +32,37 @@ module Code
         return unless validate_team_file && validate_team_options
 
         save_team if options[:team]
-        team_name = IO.read(@default_team_file)
-        puts "configured: #{team_name}"
+        puts "default team: #{default_team}"
       end
 
       private
 
+      def setup_checker
+        @checker = Code::Ownership::Checker.new(@repo, options[:from], options[:to])
+        @checker.when_useless_pattern = lambda do |record|
+          suggest_fix_for record
+        end
+
+        @checker.when_new_file = lambda do |file|
+          suggest_add_to_codeowners file
+        end
+
+        @checker.when_deleted_file = lambda do |file|
+          suggest_remove_from_codeowners file
+        end
+      end
+
       def save_team
         team_name = '@toptal/' + options[:team]
-        File.open(@default_team_file, 'w+') { |file| file.puts team_name }
+        File.open(default_team_file, 'w+') { |file| file.puts team_name }
       end
 
       def validate_team_options
         return true unless options[:team]
 
-        if options[:team] == 'team'
-          puts 'Please provide a team name.',
-               "Use #{$PROGRAM_NAME} --team <team-name>"
-          return false
-        end
+        return banner_how_to_config_team if options[:team] == 'team'
+
         true
-      end
-
-      def validate_team_file
-        return true if File.exist?(@default_team_file) || options[:team]
-
-        puts 'Team name should be specified or a default team defined',
-             "Try `#{$PROGRAM_NAME} --team <team-name>` to configure the team."
-        false
       end
 
       def write_codeowners_file
@@ -163,20 +79,19 @@ module Code
 
         owner = ask('File owner(s): ')
 
-        if owner && !owner.empty?
-          @checker.codeowners_file.append pattern: file, owners: owner
-          write_codeowners_file
-        end
+        return if owner.nil? || owner.empty?
+
+        @checker.codeowners_file.append pattern: file, owners: owner
+        write_codeowners_file
       end
 
       def suggest_remove_from_codeowners(file)
         record = @checker.codeowners_file.find_record_for_pattern pattern: file
-        if record
-          return unless yes?("File deleted: #{file}. Remove corresponding pattern from CODEOWNERS?")
+        return unless record
+        return unless yes?("File deleted: #{file}. Remove corresponding pattern from CODEOWNERS?")
 
-          @checker.codeowners_file.delete line: record.line
-          write_codeowners_file
-        end
+        @checker.codeowners_file.delete line: record.line
+        write_codeowners_file
       end
 
       def suggest_fix_for(record)
@@ -186,13 +101,22 @@ module Code
         apply_suggestion(record, suggestion) if suggestion
       end
 
-      def apply_suggestion(record, suggestion)
-        result = ask("Pattern #{record.pattern} doesn't match. Replace with: #{suggestion} (y), ignore (i) or delete pattern (d)?", limited_to: %w[y i d])
-        return if result == 'i'
+      def make_suggestion(record, suggestion)
+        ask(<<~QUESTION, limited_to: %w[y i d])
+          Pattern #{record.pattern} doesn't match.
+          Replace with: #{suggestion}?
+          (y) to apply the suggestion
+          (i) to ignore
+          (d) to delete the pattern
+        QUESTION
+      end
 
-        if result == 'y'
+      def apply_suggestion(record, suggestion)
+        case make_suggestion(record, suggestion)
+        when 'i' then return
+        when 'y'
           @checker.codeowners_file.update line: record.line, pattern: suggestion
-        elsif result == 'd'
+        when 'd'
           @checker.codeowners_file.delete line: record.line
         end
         write_codeowners_file

--- a/lib/code/ownership/cli_base.rb
+++ b/lib/code/ownership/cli_base.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Code
+  module Ownership
+    # CLIBase collects shared methods used by all CLI sub commands
+    # It loads and validate the default config file or output an explanation
+    # about how to configure it.
+    class CLIBase < Thor
+      def initialize(*args)
+        super
+        @repo_base_path = `git rev-parse --show-toplevel`.chomp
+      end
+
+      no_commands do
+        def default_team_file
+          @repo_base_path + '/.default_team'
+        end
+
+        def default_team
+          return unless File.exist?(default_team_file)
+
+          IO.read(default_team_file).chomp
+        end
+
+        def validate_team_file
+          return true if File.exist?(default_team_file) || options[:team]
+
+          banner_how_to_config_team
+        end
+
+        def banner_how_to_config_team
+          puts 'Please provide a team name or configure a default team.',
+               "Try `#{$PROGRAM_NAME} config --team <team-name>` to configure the team."
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/code/ownership/filter.rb
+++ b/lib/code/ownership/filter.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative 'checker'
+require_relative 'cli_base'
+
+# frozen_string_literal: true
+module Code
+  module Ownership
+    # Command Line Interface used by bin/code-owners-checker.
+    class Filter < CLIBase
+      option :from, default: 'origin/master'
+      option :to, default: 'HEAD'
+      option :verbose, default: false, type: :boolean, aliases: '-v'
+      desc 'by <owner>', <<~DESC
+        Lists changed files owned by TEAM.
+        If no team is specified, default team is taken from .default_team.
+      DESC
+      # option :local, default: false, type: :boolean, aliases: '-l'
+      # option :branch, default: '', aliases: '-b'
+      def by(team_name = default_team)
+        return if team_name.nil? && !validate_team_file
+
+        changes = checker.changes_with_ownership(team_name)
+        if changes.key?(team_name)
+          changes.values.each { |file| puts file }
+        else
+          puts "Owner #{team_name} not defined in .github/CODEOWNERS"
+        end
+      end
+
+      option :from, default: 'origin/master'
+      option :to, default: 'HEAD'
+      option :verbose, default: false, type: :boolean, aliases: '-v'
+      desc 'all', 'Lists all changed files grouped by owner'
+      def all
+        changes = checker.changes_with_ownership.select { |_owner, val| val && !val.empty? }
+        changes.keys.each do |owner|
+          puts(owner + ":\n  " + changes[owner].join("\n  ") + "\n\n")
+        end
+      end
+
+      def initialize(args = [], options = {}, config = {})
+        super
+        @repo_base_path = `git rev-parse --show-toplevel`
+        @default_team_file = @repo_base_path.chomp + '/.default_team'
+        if !@repo_base_path || @repo_base_path.empty?
+          raise 'You must be positioned in a git repository to use this tool'
+        end
+
+        @repo_base_path.chomp!
+        Dir.chdir(@repo_base_path)
+      end
+
+      default_task :by
+
+      private
+
+      def checker
+        @checker ||= Code::Ownership::Checker.new(@repo_base_path, options[:from], options[:to])
+      end
+    end
+  end
+end

--- a/spec/code/ownership/checker_spec.rb
+++ b/spec/code/ownership/checker_spec.rb
@@ -205,6 +205,7 @@ RSpec.describe Code::Ownership::Checker do
         expect(subject.changes_with_ownership('@jonatas')).to eq('@jonatas' => ['.rubocop.yml'])
       end
     end
+
     context 'when changing files from multiple owners' do
       let(:from) { 'HEAD~1' }
 
@@ -220,8 +221,8 @@ RSpec.describe Code::Ownership::Checker do
       specify do
         changes_from = subject.method(:changes_with_ownership)
         expect(changes_from['@jonatas']).to eq('@jonatas' => [])
-        expect(changes_from['@toptal/rogue-one']).to eq('@toptal/rogue-one' => ["lib/shared/file.rb"])
-        expect(changes_from['@toptal/billing']).to eq('@toptal/billing' => ["lib/shared/file.rb"])
+        expect(changes_from['@toptal/rogue-one']).to eq('@toptal/rogue-one' => ['lib/shared/file.rb'])
+        expect(changes_from['@toptal/billing']).to eq('@toptal/billing' => ['lib/shared/file.rb'])
       end
     end
   end

--- a/spec/code/ownership/cli_spec.rb
+++ b/spec/code/ownership/cli_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Code::Ownership::CLI do
     it 'validates team file existence' do
       expect do
         cli.config
-      end.to output(/Team name should be specified or a default team defined/).to_stdout
+      end.to output(/Please provide a team name or configure a default team/).to_stdout
     end
 
     context 'when I have the file configured' do
@@ -28,7 +28,7 @@ RSpec.describe Code::Ownership::CLI do
       it 'shows the current team from file' do
         expect do
           cli.config
-        end.to output("configured: @toptal/bootcamp\n").to_stdout
+        end.to output("default team: @toptal/bootcamp\n").to_stdout
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Code::Ownership::CLI do
       it 'allow config a new team with the team parameter' do
         expect do
           cli.config
-        end.to output("configured: @toptal/blacksmiths\n").to_stdout
+        end.to output("default team: @toptal/blacksmiths\n").to_stdout
       end
     end
 

--- a/spec/code/ownership/filter_spec.rb
+++ b/spec/code/ownership/filter_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe Code::Ownership::Filter do
+  subject(:cli) { described_class.new(args, options, config) }
+
+  let(:args) { [] }
+  let(:options) { {} }
+  let(:config) { {} }
+
+  describe '#default_team' do
+    context 'when I have the file configured' do
+      before do
+        File.open(cli.default_team_file, 'w+') do |file|
+          file.puts '@toptal/bootcamp'
+        end
+      end
+
+      after do
+        File.delete(cli.default_team_file) if File.exist?(cli.default_team_file)
+      end
+
+      it 'uses the config file to restore the team name' do
+        expect(cli.default_team).to eq('@toptal/bootcamp')
+      end
+    end
+
+    context 'when the config file does not exist' do
+      it 'returns nil' do
+        expect(cli.default_team).to be_nil
+      end
+    end
+  end
+
+  describe '#by' do
+    let(:diff) { { '@toptal/bootcamp' => ['lib/shared/file.rb'] } }
+
+    before do
+      checker = double
+      allow(checker).to receive(:changes_with_ownership).and_return(diff)
+      allow(cli).to receive(:checker).and_return(checker)
+    end
+
+    context 'when filter by explicity owner' do
+      let(:args) { %w[by @toptal/bootcamp] }
+
+      it 'applies the user input as the filter' do
+        expect(cli).not_to receive(:default_team)
+        expect do
+          cli.by(args.last)
+        end.to output(<<~OUTPUT).to_stdout
+          lib/shared/file.rb
+        OUTPUT
+      end
+    end
+
+    context 'when do not pass any parameter' do
+      let(:args) { %w[] }
+
+      it 'applies `by` with `default_team`' do
+        expect(cli).to receive(:default_team).and_return('@toptal/bootcamp')
+        cli.by
+      end
+    end
+
+    context 'when the team passed does not have any occurrence' do
+      let(:args) { %w[] }
+
+      it 'does not show any file' do
+        expect do
+          cli.by('@toptal/other')
+        end.to output(<<~OUTPUT).to_stdout
+          Owner @toptal/other not defined in .github/CODEOWNERS
+        OUTPUT
+      end
+    end
+  end
+end


### PR DESCRIPTION
When filtering changes by a team, the team from the default_team file wasn’t used and was used empty team instead. Now it uses the team specified in the config file. 