### PR TITLE
Non interactive mode report errors

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -35,7 +35,7 @@ module Codeowners
     end
 
     def check!
-      {
+      @results ||= {
         missing_ref: missing_reference,
         useless_pattern: useless_pattern
       }
@@ -107,12 +107,14 @@ module Codeowners
       codeowners.main_group
     end
 
+    def consistent?
+      check!.values.all?(&:empty?)
+    end
+
     def commit_changes!
       @git.add(codeowners_filename)
       @git.commit('Fix pattern :robot:')
     end
-
-    private
 
     def codeowners_filename
       directories = ['', '.github', 'docs', '.gitlab']

--- a/spec/codeowners/checker/group_spec.rb
+++ b/spec/codeowners/checker/group_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Codeowners::Checker::Group do
     context 'when subgroups owned by desired owner exist' do
       it 'returns array of subgroups owned by owner' do
         subgroups = subject.subgroups_owned_by('@owner')
-        expect(subgroups.map(&:title)).to eq(['#group1', '#group2', '# BEGIN group 3', "##group3.2"])
+        expect(subgroups.map(&:title)).to eq(['#group1', '#group2', '# BEGIN group 3', '##group3.2'])
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Codeowners::Checker::Group do
 
       it 'returns array of subgroups owned by owner' do
         subgroups = subject.subgroups_owned_by('@owner')
-        expect(subgroups.map(&:title)).to eq(['#group1', '#group2', '# BEGIN group 3', "##group3.2"])
+        expect(subgroups.map(&:title)).to eq(['#group1', '#group2', '# BEGIN group 3', '##group3.2'])
       end
     end
   end


### PR DESCRIPTION
We introduce non-interactive mode to run on CI:

Here is the example of output running with `-i=false`

```
File ./.github/CODEOWNERS is inconsistent:
No owner defined
------------------------------
file1.rb
file2.rb
------------------------------
Useless patterns
------------------------------
file/not/found.rb @user
other/useless/pattern/* @team/useless
```