### PR TITLE
Exclude some files from the gem

### DIFF
--- a/codeowners-checker.gemspec
+++ b/codeowners-checker.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Check consistency of Github CODEOWNERS and git changes.'
   spec.license       = 'MIT'
 
-  spec.files = Dir.glob("{lib}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
+  spec.files = Dir["codeowners-checker.gemspec", "*.{md,txt}", "lib/**/*.rb"]
   spec.bindir        = 'bin'
   spec.executables   = ['codeowners-checker']
   spec.require_paths = ['lib']

--- a/codeowners-checker.gemspec
+++ b/codeowners-checker.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Check consistency of Github CODEOWNERS and git changes.'
   spec.license       = 'MIT'
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files = Dir.glob("{lib}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
   spec.bindir        = 'bin'
   spec.executables   = ['codeowners-checker']
   spec.require_paths = ['lib']


### PR DESCRIPTION
Hello,
I have a proposal to exclude some files from this gem.
What do you think about this change?

With this change, I have excluded files such as:
- .gitignore,
- .projections.json,
- .rspec,
- .rubocop.yml,
- .travis.yml,
- CODE_OF_CONDUCT.md,
- Gemfile,
- Gemfile.lock,
- Guardfile,
- Rakefile,
- bin/console,
- bin/setup,
- demos/missing_reference.svg,
- demos/useless_pattern.svg
