### PR TITLE
Add options when adding patterns and suggesting changes

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -35,10 +35,12 @@ module Codeowners
     end
 
     def check!
-      @results ||= {
-        missing_ref: missing_reference,
-        useless_pattern: useless_pattern
-      }
+      catch(:user_quit) do
+        @results ||= {
+          missing_ref: missing_reference,
+          useless_pattern: useless_pattern
+        }
+      end
     end
 
     def changes_for_patterns(patterns)

--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -34,13 +34,8 @@ module Codeowners
       changes_to_analyze.select { |_k, v| v == 'A' }.keys
     end
 
-    def check!
-      catch(:user_quit) do
-        @results ||= {
-          missing_ref: missing_reference,
-          useless_pattern: useless_pattern
-        }
-      end
+    def fix!
+      catch(:user_quit) { results }
     end
 
     def changes_for_patterns(patterns)
@@ -110,7 +105,7 @@ module Codeowners
     end
 
     def consistent?
-      check!.values.all?(&:empty?)
+      results.values.all?(&:empty?)
     end
 
     def commit_changes!
@@ -122,6 +117,16 @@ module Codeowners
       directories = ['', '.github', 'docs', '.gitlab']
       paths = directories.map { |dir| File.join(@repo_dir, dir, 'CODEOWNERS') }
       Dir.glob(paths).first || paths.first
+    end
+
+    private
+
+    def results
+      @results ||=
+        {
+          missing_ref: missing_reference,
+          useless_pattern: useless_pattern
+        }
     end
   end
 end

--- a/lib/codeowners/checker/group/pattern.rb
+++ b/lib/codeowners/checker/group/pattern.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'line'
+require_relative '../owner'
 
 module Codeowners
   class Checker
@@ -12,7 +13,7 @@ module Codeowners
 
         def self.match?(line)
           _pattern, *owners = line.split(/\s+/)
-          owners.any? && owners.all? { |owner| owner.include?('@') }
+          Owner.valid?(*owners)
         end
 
         def initialize(line)

--- a/lib/codeowners/checker/owner.rb
+++ b/lib/codeowners/checker/owner.rb
@@ -1,0 +1,9 @@
+module Codeowners
+  class Checker
+    module Owner
+      def self.valid?(*owners)
+        owners.any? && owners.all? { |owner| owner.include?('@') }
+      end
+    end
+  end
+end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -19,8 +19,6 @@ module Codeowners
       desc 'check REPO', 'Checks .github/CODEOWNERS consistency'
       # for pre-commit: --from HEAD --to index
       def check(repo = '.')
-        @codeowners_changed = false
-        @ignore = { suggestions: false, added_files: false }
         @repo = repo
         setup_checker
         @checker.check!
@@ -62,12 +60,12 @@ module Codeowners
       end
 
       def suggest_add_to_codeowners(file)
-        return if @ignore[:added_files]
+        return if @quit
 
         case add_to_codeowners_dialog(file)
         when 'y' then add_to_codeowners(file)
         when 'i' then return
-        when 'q' then @ignore[:added_files] = true
+        when 'q' then @quit = true
         end
       end
 
@@ -76,7 +74,7 @@ module Codeowners
           File added: #{file.inspect}. Add owner to the CODEOWNERS file?
           (y) yes
           (i) ignore
-          (q) ignore all added files
+          (q) quit
         QUESTION
       end
 
@@ -145,7 +143,7 @@ module Codeowners
       end
 
       def suggest_fix_for(line)
-        return if @ignore[:suggestions]
+        return if @quit
 
         search = FuzzyMatch.new(line.suggest_files_for_pattern)
         suggestion = search.find(line.pattern)
@@ -172,7 +170,7 @@ module Codeowners
         when 'd'
           line.remove!
         when 'q'
-          @ignore[:suggestions] = true
+          @quit = true
         end
       end
 
@@ -183,7 +181,7 @@ module Codeowners
           (i) ignore
           (e) edit the pattern
           (d) delete the pattern
-          (q) ignore all
+          (q) quit
         QUESTION
       end
 
@@ -192,7 +190,7 @@ module Codeowners
         when 'e' then pattern_change(line)
         when 'i' then nil
         when 'd' then line.remove!
-        when 'q' then @ignore[:suggestions] = true
+        when 'q' then @quit = true
         end
       end
 
@@ -201,7 +199,7 @@ module Codeowners
           (e) edit the pattern
           (d) delete the pattern
           (i) ignore
-          (q) ignore all
+          (q) quit
         QUESTION
       end
 

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 require 'codeowners/checker'
 
 RSpec.describe Codeowners::Checker do
-  subject { described_class.new(folder_name, from, to).check! }
+  subject { described_class.new(folder_name, from, to).fix! }
 
   let(:folder_name) { 'project' }
   let(:from) { 'HEAD' }


### PR DESCRIPTION
When adding new patterns the owners from CODEOWNERS file are listed and the user can choose one of the owners, use the configured default owner, or add a new one.
Also when suggestions are made, option for skipping all the suggestions is now available.