### PR TITLE
Support Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.3.8
+  - 2.4.5
   - 2.5.0
+  - 2.6.1
 before_install: gem install bundler -v 1.16.1

--- a/lib/codeowners/checker/code_owners.rb
+++ b/lib/codeowners/checker/code_owners.rb
@@ -38,7 +38,8 @@ module Codeowners
       private
 
       def list
-        @list ||= @file_manager.content.yield_self do |list|
+        @list ||= begin
+          list = @file_manager.content
           transform_line_procs.each do |transform_line_proc|
             list = list.flat_map { |line| transform_line_proc.call(line) }.compact
           end

--- a/lib/codeowners/checker/group.rb
+++ b/lib/codeowners/checker/group.rb
@@ -108,7 +108,7 @@ module Codeowners
 
       def remove(line)
         @list.safe_delete(line)
-        remove! unless any?(Pattern)
+        remove! unless any? { |object| object.is_a? Pattern }
       end
 
       def remove!

--- a/lib/codeowners/checker/group/group_begin_comment.rb
+++ b/lib/codeowners/checker/group/group_begin_comment.rb
@@ -9,7 +9,7 @@ module Codeowners
       # of a group.
       class GroupBeginComment < Comment
         def self.match?(line)
-          line.lstrip.start_with?(/^#+ BEGIN/)
+          line.lstrip =~ /^#+ BEGIN/
         end
       end
     end

--- a/lib/codeowners/checker/group/group_end_comment.rb
+++ b/lib/codeowners/checker/group/group_end_comment.rb
@@ -9,7 +9,7 @@ module Codeowners
       # of a group.
       class GroupEndComment < Comment
         def self.match?(line)
-          line.lstrip.start_with?(/^#+ END/)
+          line.lstrip =~ /^#+ END/
         end
       end
     end


### PR DESCRIPTION
This is my attempt at solving https://github.com/toptal/codeowners-checker/issues/50.

This PR is focusing on replacing newer features of Ruby with older ones. I have personally tested it against:
- Ruby 2.2.4 => Fails on lonely operator
- Ruby 2.3.8 => ✅
- Ruby 2.4.5 => ✅
- Ruby 2.5.1 => for some reason I'm getting a weird error with bundler but for this one version I can trust this repo's CI as I see 2.5 is defined in [`.travis.yml`](https://github.com/toptal/codeowners-checker/blob/master/.travis.yml#L4)
- Ruby 2.6.1 => ✅

~~I would also love to add these Ruby versions on the `.travis.yml` file but I cannot find a link to the Travis CI pipeline.~~ Nevermind, now I see it.