### PR TITLE
Some systems don't have `command` executable, fix `fzf` detection for them

### DIFF
--- a/lib/codeowners/cli/suggest_file_from_pattern.rb
+++ b/lib/codeowners/cli/suggest_file_from_pattern.rb
@@ -26,7 +26,7 @@ module Codeowners
 
       # Checks if fzf is installed.
       def self.installed_fzf?
-        `command -v fzf` != ''
+        system('fzf --version > /dev/null 2>&1')
       end
     end
 


### PR DESCRIPTION
Currently `codeowners-checker check` fails with 
```
Pattern "x/.rubocop.yml" doesn't match.
Traceback (most recent call last):
	30: from /home/ojab/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `<main>'
	29: from /home/ojab/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `eval'
	28: from /home/ojab/.rvm/gems/ruby-2.5.5/bin/codeowners-checker:23:in `<main>'
	27: from /home/ojab/.rvm/gems/ruby-2.5.5/bin/codeowners-checker:23:in `load'
	26: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/bin/codeowners-checker:8:in `<top (required)>'
	25: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	24: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	23: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	22: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	21: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/main.rb:26:in `check'
	20: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/main.rb:41:in `interactive_mode'
	19: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:38:in `fix!'
	18: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:38:in `catch'
	17: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:38:in `block in fix!'
	16: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:128:in `results'
	15: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:67:in `useless_pattern'
	14: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:67:in `select'
	13: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/code_owners.rb:31:in `each'
	12: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:24:in `each'
	11: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:24:in `each'
	10: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:26:in `block in each'
	 9: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:24:in `each'
	 8: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:24:in `each'
	 7: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker/group.rb:28:in `block in each'
	 6: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:71:in `block in useless_pattern'
	 5: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/checker.rb:71:in `call'
	 4: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/main.rb:156:in `suggest_fix_for'
	 3: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/suggest_file_from_pattern.rb:20:in `pick_suggestion'
	 2: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/suggest_file_from_pattern.rb:24:in `strategy_class'
	 1: from /home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/suggest_file_from_pattern.rb:29:in `installed_fzf?'
/home/ojab/.rvm/gems/ruby-2.5.5/gems/codeowners-checker-1.0.2/lib/codeowners/cli/suggest_file_from_pattern.rb:29:in ``': No such file or directory - command (Errno::ENOENT)
```
here