### PR TITLE
Restrict `*` to files while `**` include folders in depht

### DIFF
--- a/lib/codeowners/checker/group/pattern.rb
+++ b/lib/codeowners/checker/group/pattern.rb
@@ -33,10 +33,14 @@ module Codeowners
         end
 
         def match_file?(file)
-          if !pattern.include?('/') || pattern.include?('**')
-            File.fnmatch(pattern.gsub(%r{^/}, ''), file, File::FNM_DOTMATCH)
+          File.fnmatch(pattern.gsub(%r{^/}, ''), file, fn_options)
+        end
+
+        def fn_options
+          if pattern.include?('**')
+            File::FNM_DOTMATCH
           else
-            File.fnmatch(pattern.gsub(%r{^/}, ''), file, File::FNM_PATHNAME | File::FNM_DOTMATCH)
+            File::FNM_DOTMATCH | File::FNM_PATHNAME
           end
         end
 

--- a/spec/codeowners/checker/group/pattern_spec.rb
+++ b/spec/codeowners/checker/group/pattern_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Codeowners::Checker::Group::Pattern do
         'dir/file.rb' => false,
         'dir/dir1/file.rb' => true,
         'dir/dir1/other_file.rb' => true,
+        'other/dir/dir1/other_file.rb' => false,
         'dir/dir1/dir2/file.rb' => false
       },
       'dir/*/file.rb @owner' => {
@@ -59,6 +60,15 @@ RSpec.describe Codeowners::Checker::Group::Pattern do
       },
       '*.js @owner' => {
         'file.rb' => false,
+        'file.js' => true,
+        'another_file.js' => true,
+        'dir/file.js' => false,
+        'dir/dir1/file.rb' => false,
+        'dir/dir1/file1.js' => false,
+        'dir/dir1/dir2/file.js' => false
+      },
+      '**.js @owner' => {
+        'file.rb' => false,
         'dir/file.js' => true,
         'dir/dir1/file.rb' => false,
         'dir/dir1/file1.js' => true,
@@ -66,10 +76,14 @@ RSpec.describe Codeowners::Checker::Group::Pattern do
       },
       '* @owner' => {
         '.file.rb' => true,
+        'directory/.file.rb' => false,
+        'directory/subdirectory/file.rb' => false
+      },
+      '** @owner' => {
+        '.file.rb' => true,
         'directory/.file.rb' => true,
         'directory/subdirectory/file.rb' => true
       }
-
     }.each do |content, tests|
       context "when the line is #{content.inspect}" do
         let(:line) { content }

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Codeowners::Checker do
           Dir.mkdir('app')
           File.open(filename, 'w+') { |file| file.puts '# add some ruby code here' }
           File.open(filename2, 'w+') { |file| file.puts '# add some ruby code here' }
-          File.open('.github/CODEOWNERS', 'a+') { |f| f.puts '*.js @owner3' }
+          File.open('.github/CODEOWNERS', 'a+') { |f| f.puts '**.js @owner3' }
 
           git.add filename
           git.add filename2


### PR DESCRIPTION
It fixes #51.

As the official [documentation](https://git-scm.com/docs/gitignore#_pattern_format) says:

> A trailing "/**" matches everything inside. For example, "abc/**" matches all files inside directory "abc", relative to the location of the .gitignore file, with infinite depth.

As code owners system does not make sense to work with relative paths, this only fixes the issue related that `*` means everything in the current level but not subfolders while `**` covers the depth.