### PR TITLE
Create separate classes to handle OWNERS

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -6,6 +6,7 @@ require 'logger'
 require_relative 'checker/code_owners'
 require_relative 'checker/file_as_array'
 require_relative 'checker/group'
+require_relative 'checker/owners_list'
 
 module Codeowners
   # Check if code owners are consistent between a git repository and the CODEOWNERS file.
@@ -14,8 +15,7 @@ module Codeowners
   # By default (:validate_owners property) it also reads OWNERS with list of all
   # possible/valid owners and validates every owner in CODEOWNERS is defined in OWNERS
   class Checker
-    attr_accessor :when_useless_pattern, :when_new_file, :when_new_owner, :validate_owners
-    attr_writer :owners_list
+    attr_accessor :when_useless_pattern, :when_new_file, :owners_list
 
     # Get repo metadata and compare with the owners
     def initialize(repo, from, to)
@@ -23,7 +23,7 @@ module Codeowners
       @repo_dir = repo
       @from = from || 'HEAD'
       @to = to
-      @validate_owners = true
+      @owners_list = OwnersList.new(ownerslist_filename)
     end
 
     def transformers
@@ -78,18 +78,6 @@ module Codeowners
       end
     end
 
-    def invalid_owner
-      return [] unless @validate_owners
-
-      codeowners.select do |line|
-        next unless line.pattern?
-
-        missing = line.owners - owners_list
-        missing.each { |owner| @when_new_owner&.call(line, owner) }
-        missing.any?
-      end
-    end
-
     def missing_reference
       added_files.reject(&method(:defined_owner?))
     end
@@ -109,32 +97,11 @@ module Codeowners
       false
     end
 
-    def valid_owner?(owner)
-      !@validate_owners || owners_list.include?(owner)
-    end
-
     def codeowners
       @codeowners ||= CodeOwners.new(
         FileAsArray.new(codeowners_filename),
         transformers: transformers
       )
-    end
-
-    def owners_list
-      return [] unless @validate_owners
-
-      @owners_list ||=
-        if github_credentials_exist?
-          Codeowners::GithubFetcher.get_owners(ENV['GITHUB_ORGANIZATION'], ENV['GITHUB_TOKEN'])
-        else
-          FileAsArray.new(ownerslist_filename).content
-        end
-    end
-
-    def persist_owners_list!
-      owners_file = FileAsArray.new(ownerslist_filename)
-      owners_file.content = @owners_list
-      owners_file.persist!
     end
 
     def main_group
@@ -151,21 +118,23 @@ module Codeowners
       @git.commit('Fix pattern :robot:')
     end
 
-    def ownerslist_filename
+    def self.ownerslist_filename(repo_dir)
       # doing gsub here ensures the files are always in the same directory
-      codeowners_filename.gsub('CODEOWNERS', 'OWNERS')
+      codeowners_filename(repo_dir).gsub('CODEOWNERS', 'OWNERS')
+    end
+
+    def ownerslist_filename
+      self.class.ownerslist_filename(@repo_dir)
     end
 
     def codeowners_filename
-      directories = ['', '.github', 'docs', '.gitlab']
-      paths = directories.map { |dir| File.join(@repo_dir, dir, 'CODEOWNERS') }
-      Dir.glob(paths).first || paths.first
+      self.class.codeowners_filename(@repo_dir)
     end
 
-    def github_credentials_exist?
-      token = ENV['GITHUB_TOKEN']
-      organization = ENV['GITHUB_ORGANIZATION']
-      token && organization
+    def self.codeowners_filename(repo_dir)
+      directories = ['', '.github', 'docs', '.gitlab']
+      paths = directories.map { |dir| File.join(repo_dir, dir, 'CODEOWNERS') }
+      Dir.glob(paths).first || paths.first
     end
 
     private
@@ -175,7 +144,7 @@ module Codeowners
         {
           missing_ref: missing_reference,
           useless_pattern: useless_pattern,
-          invalid_owner: invalid_owner
+          invalid_owner: @owners_list.invalid_owner(@codeowners)
         }
     end
   end

--- a/lib/codeowners/checker/owners_list.rb
+++ b/lib/codeowners/checker/owners_list.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'file_as_array'
+
+module Codeowners
+  class Checker
+    # Manage OWNERS file reading, re-writing and fetching
+    class OwnersList
+      attr_accessor :validate_owners, :when_new_owner, :ownerslist_filename
+      attr_writer :owners
+
+      def initialize(ownerslist_filename)
+        @validate_owners = true
+        @ownerslist_filename = ownerslist_filename
+      end
+
+      def persist!
+        owners_file = FileAsArray.new(@ownerslist_filename)
+        owners_file.content = @owners
+        owners_file.persist!
+      end
+
+      def valid_owner?(owner)
+        !@validate_owners || owners.include?(owner)
+      end
+
+      def owners
+        return [] unless @validate_owners
+
+        @owners ||=
+          if github_credentials_exist?
+            Codeowners::GithubFetcher.get_owners(ENV['GITHUB_ORGANIZATION'], ENV['GITHUB_TOKEN'])
+          else
+            FileAsArray.new(@ownerslist_filename).content
+          end
+      end
+
+      def github_credentials_exist?
+        token = ENV['GITHUB_TOKEN']
+        organization = ENV['GITHUB_ORGANIZATION']
+        token && organization
+      end
+
+      def invalid_owner(codeowners)
+        return [] unless @validate_owners
+
+        codeowners.select do |line|
+          next unless line.pattern?
+
+          missing = line.owners - owners
+          missing.each { |owner| @when_new_owner&.call(line, owner) }
+          missing.any?
+        end
+      end
+
+      def <<(owner)
+        @owners << owner
+      end
+    end
+  end
+end

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative '../checker'
+require_relative '../checker/owners_list'
+
+module Codeowners
+  module Cli
+    # Command Line Interface dealing with OWNERS generation and validation
+    class OwnersListHandler < Base
+      attr_writer :checker
+      attr_reader :content_changed
+      default_task :fetch
+
+      def initialize
+        @content_changed = false
+        super
+      end
+
+      desc 'fetch REPO', 'Fetches .github/OWNERS based on github organization'
+      def fetch(repo = '.')
+        @repo = repo
+        owners = owners_from_github
+        owners_list = Checker::OwnersList.new(Codeowners::Checker.ownerslist_filename(repo))
+        owners_list.owners = owners
+        owners_list.persist!
+      end
+
+      no_commands do
+        def owners_from_github
+          organization = ENV['GITHUB_ORGANIZATION']
+          organization ||= ask('GitHub organization (e.g. github): ')
+          token = ENV['GITHUB_TOKEN']
+          token ||= ask('Enter GitHub token: ', echo: false)
+          puts 'Fetching owners list from GitHub ...'
+          Codeowners::GithubFetcher.get_owners(organization, token)
+        end
+
+        def suggest_add_to_owners_list(line, owner)
+          case add_to_ownerslist_dialog(line, owner)
+          when 'y' then add_to_ownerslist(owner)
+          when 'i' then nil
+          when 'q' then throw :user_quit
+          end
+        end
+
+        def add_to_ownerslist_dialog(line, owner)
+          ask(<<~QUESTION, limited_to: %w[y i q])
+            Unknown owner: #{owner} for pattern: #{line.pattern}. Add owner to the OWNERS file?
+            (y) yes
+            (i) ignore
+            (q) quit and save
+          QUESTION
+        end
+
+        def add_to_ownerslist(owner)
+          @checker.owners_list << owner
+          @content_changed = true
+        end
+
+        def create_new_pattern_with_owner(file, sorted_owners)
+          loop do
+            owner = new_owner(sorted_owners)
+
+            unless Codeowners::Checker::Owner.valid?(owner)
+              puts "#{owner.inspect} is not a valid owner name. Try again."
+              next
+            end
+
+            return Codeowners::Checker::Group::Pattern.new("#{file} #{owner}")
+          end
+        end
+
+        def create_new_pattern_with_validated_owner(file, sorted_owners)
+          # first make sure we have the '@' sign in owner
+          pattern = create_new_pattern_with_owner(file, sorted_owners)
+          return pattern if @checker.owners_list.valid_owner?(pattern.owner)
+
+          # The following call will either
+          #   - (i)gnore: the bad owner and thus the user intention is explicit and we will create the Pattern
+          #   - (y)es: user is added to OWNERS and thus the Pattern will be valid
+          # The side-effect of ignore is that the same validation and the same question will be asked again
+          # after the pattern validation finishes and the owners validation starts
+          suggest_add_to_owners_list(pattern, pattern.owner)
+          pattern
+        end
+
+        def new_owner(sorted_owners)
+          owner = ask('New owner: ')
+
+          if owner.to_i.between?(1, sorted_owners.length)
+            sorted_owners[owner.to_i - 1]
+          elsif owner.empty?
+            @config.default_owner
+          else
+            owner
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/codeowners/checker/owners_list_spec.rb
+++ b/spec/codeowners/checker/owners_list_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'codeowners/checker/owners_list'
+
+RSpec.describe Codeowners::Checker::OwnersList do
+  subject { described_class.new(File.join(folder_name, '.github/OWNERS')) }
+
+  let(:folder_name) { 'project' }
+
+  ENV['GITHUB_TOKEN'] = nil
+  ENV['GITHUB_ORGANIZATION'] = nil
+
+  before do
+    on_project_folder do
+      Dir.mkdir('.github')
+      File.open('.github/OWNERS', 'w+') do |file|
+        file.puts <<~CONTENT
+          @owner
+          @owner1
+          @owner2
+        CONTENT
+      end
+    end
+  end
+
+  def on_project_folder
+    Dir.mkdir(folder_name) unless Dir.exist?(folder_name)
+    Dir.chdir(folder_name) do
+      yield
+    end
+  end
+
+  after do
+    FileUtils.rm_r(folder_name)
+  end
+
+  describe '#valid_owner?' do
+    before do
+      subject.owners
+    end
+
+    context 'when load OWNERS' do
+      it 'validates owner from file' do
+        expect(subject).to be_valid_owner('@owner1')
+        expect(subject).not_to be_valid_owner('@unknown')
+      end
+    end
+
+    context 'when skip owner validation' do
+      before do
+        subject.validate_owners = false
+      end
+
+      it 'returns true' do
+        expect(subject).to be_valid_owner('@unknown')
+      end
+    end
+  end
+
+  describe '#persist!' do
+    before do
+      subject.owners = []
+    end
+
+    context 'when new user is added to owners_list' do
+      before do
+        subject.owners << '@new_owner'
+        subject.persist!
+      end
+
+      it 'writes the user to OWNERS' do
+        expect(File.read(subject.ownerslist_filename)).to eq("@new_owner\n")
+      end
+    end
+  end
+end

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Codeowners::Checker do
       subject { described_class.new folder_name, from, to }
 
       before do
-        subject.validate_owners = false
+        subject.owners_list.validate_owners = false
       end
 
       it 'does not complain' do
@@ -339,50 +339,6 @@ RSpec.describe Codeowners::Checker do
          'lib/shared/* @owner2 @owner1']
       )
       expect(subject.main_group).to be_a(Codeowners::Checker::Group)
-    end
-  end
-
-  describe '#valid_owner?' do
-    subject { described_class.new folder_name, from, to }
-
-    before do
-      subject.owners_list
-    end
-
-    context 'when load OWNERS' do
-      it 'validates owner from file' do
-        expect(subject).to be_valid_owner('@owner1')
-        expect(subject).not_to be_valid_owner('@unknown')
-      end
-    end
-
-    context 'when skip owner validation' do
-      before do
-        subject.validate_owners = false
-      end
-
-      it 'returns true' do
-        expect(subject).to be_valid_owner('@unknown')
-      end
-    end
-  end
-
-  describe '#persist_owners_list!' do
-    subject { described_class.new folder_name, from, to }
-
-    before do
-      subject.owners_list = []
-    end
-
-    context 'when new user is added to owners_list' do
-      before do
-        subject.owners_list << '@new_owner'
-        subject.persist_owners_list!
-      end
-
-      it 'writes the user to OWNERS' do
-        expect(File.read(subject.ownerslist_filename)).to eq("@new_owner\n")
-      end
     end
   end
 end


### PR DESCRIPTION
*NOTE* This is work in progress. Needs polishing and proper testing. I am, however, curious, if this direction is OK. This should be eventually merged into `bt-225-validate-owners` and squashed into a single commit with what is already there.

What is going on here -- Michael suggested (in https://github.com/toptal/codeowners-checker/pull/59/) that the checker.rb and main.rb are already quite big and all the `OWNERS` related logic should be ideally taken out. That is indeed true and I was thinking the same (but then got lazy) while writing the code.

One of the problems with the refactor is there are two different responsibilities:
  - interaction with user (via `Thor::Shell::Basic#ask?`) which lives in main.rb
  - the actual logic which compares the lists, validates, ... which lives in checker.rb

Therefore I decided to do the following:
  - create `CodeOwners::Checker::OwnersList` which encapsulates the logic
  - create `Codeowners::Cli::OwnersListHandler` which is more of a helper to `CodeOwners::Cli::Main`, has access to Thor (`ask?`)