### PR TITLE
List unrecognized lines while using `--no-interactive` flag

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -118,6 +118,12 @@ module Codeowners
       @git.commit('Fix pattern :robot:')
     end
 
+    def unrecognized_line
+      codeowners.map do |line|
+        line.to_file if line.is_a?(Codeowners::Checker::Group::UnrecognizedLine)
+      end.compact
+    end
+
     private
 
     def results
@@ -125,7 +131,8 @@ module Codeowners
         {
           missing_ref: missing_reference,
           useless_pattern: useless_pattern,
-          invalid_owner: @owners_list.invalid_owner(@codeowners)
+          invalid_owner: @owners_list.invalid_owner(@codeowners),
+          unrecognized_line: unrecognized_line
         }
     end
   end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -257,7 +257,8 @@ module Codeowners
       LABELS = {
         missing_ref: 'No owner defined',
         useless_pattern: 'Useless patterns',
-        invalid_owner: 'Invalid owner'
+        invalid_owner: 'Invalid owner',
+        unrecognized_line: 'Unrecognized line'
       }.freeze
 
       def report_errors!


### PR DESCRIPTION
Github Issue: #53 

-----------------------------------------

**Description** 
There was an inconsistency between  `--no-interactive` and `interactive` (default) mode.
If you add an unrecognizable line in `CODEOWNERS` file `codeowner-checker check` will:

* in interactive mode tell you that there's invalid line and asks to fix this line
* in no-interactive mode just be silent and won't notify the user about inconsistency

**How to test**
Add line without owner to `CODEOWNERS`. For example
```
lib/client.rb
```

and run `codeowner-checker check --no-interactive`

**Review**
- [x] Ensure the changes are covered by specs.
- [x] Test manually.

**Pre-merge checklist**
- [x] The PR relates to a single subject.
- [x] Squash related commits together.
- [x] Verify that feature branch is up-to-date with master (if not - rebase it).
