### PR TITLE
Fix coverage report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'bundler/setup'
 require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec'
+end
+
+require 'bundler/setup'
 require 'codeowners/cli/main'
 
 Dir['lib/**/*.rb'].each { |file| require file[4..-1] }
-
-SimpleCov.start do
-  add_filter '/spec/'
-end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
### 📜 Description

Currently **SimpleCov** does not measure coverage:

![before](https://user-images.githubusercontent.com/358508/68307900-04f1dd00-00bd-11ea-8fa9-2f81ca4e3f45.png)

There is a small issue with loading order in `spec_helper.rb` related to **SimpleCov**.
In accordance with [SimpleCov Setup Guide](https://github.com/colszowka/simplecov#getting-started) we have to load and lunch **SimpleCov** at the very top of `spec/spec_helper`:

```ruby
require 'simplecov'
SimpleCov.start do
  add_filter 'spec'
end

All other content of spec helper now starts here
```

So, following PR solves this issue.

### 🔬 How to test

```
$ bundle exec rspec
```
### 👓 Review

No suggestions.

### 📋 Pre-merge checklist

- [x] The PR relates to a single subject.
- [x] Squash related commits together.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).

### 🎥 Screenshots

`bundle exec rspec` after: 
![after](https://user-images.githubusercontent.com/358508/68307555-809f5a00-00bc-11ea-9b0f-144f4f145960.png)

Current coverage:
![coverage_results](https://user-images.githubusercontent.com/358508/68307544-7bdaa600-00bc-11ea-9940-8f5c40d9aaba.png)
