### PR TITLE
codeowners-checker check --no-interactive asks for user input

### DIFF
--- a/lib/codeowners/cli/interactive_helpers.rb
+++ b/lib/codeowners/cli/interactive_helpers.rb
@@ -4,6 +4,7 @@ module Codeowners
   module Cli
     # Helpers for the CLI (ask) and (yes) methods
     module InteractiveHelpers
+      # Skips any user interactions if --no-interactive option is passed
       def ask(message, *opts)
         return unless options[:interactive]
 

--- a/lib/codeowners/cli/interactive_helpers.rb
+++ b/lib/codeowners/cli/interactive_helpers.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Codeowners
   module Cli
+    # Helpers for the CLI (ask) and (yes) methods
     module InteractiveHelpers
       def ask(message, *opts)
         return unless options[:interactive]

--- a/lib/codeowners/cli/interactive_helpers.rb
+++ b/lib/codeowners/cli/interactive_helpers.rb
@@ -1,0 +1,17 @@
+module Codeowners
+  module Cli
+    module InteractiveHelpers
+      def ask(message, *opts)
+        return unless options[:interactive]
+
+        super
+      end
+
+      def yes?(message, *opts)
+        return unless options[:interactive]
+
+        super
+      end
+    end
+  end
+end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -209,7 +209,7 @@ module Codeowners
       end
 
       def pattern_change(line)
-        new_pattern =  ask("Replace pattern #{line.pattern.inspect} with: ")
+        new_pattern = ask("Replace pattern #{line.pattern.inspect} with: ")
         return if new_pattern.empty?
 
         line.pattern = new_pattern

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -12,7 +12,7 @@ require_relative '../checker/owner'
 module Codeowners
   module Cli
     # Command Line Interface used by bin/codeowners-checker.
-    class Main < Base # rubocop:disable Metrics/ClassLength
+    class Main < Base
       include InteractiveHelpers
 
       option :from, default: 'origin/master'
@@ -22,7 +22,7 @@ module Codeowners
       option :autocommit, default: false, type: :boolean, aliases: '-c'
       desc 'check REPO', 'Checks .github/CODEOWNERS consistency'
       # for pre-commit: --from HEAD --to index
-      def check(repo = '.') # rubocop:disable Metrics/MethodLength
+      def check(repo = '.')
         @content_changed = false
         @repo = repo
         setup_checker

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -14,7 +14,7 @@ module Codeowners
     # Command Line Interface used by bin/codeowners-checker.
     class Main < Base # rubocop:disable Metrics/ClassLength
       include InteractiveHelpers
-      
+
       option :from, default: 'origin/master'
       option :to, default: 'HEAD'
       option :interactive, default: true, type: :boolean, aliases: '-i'
@@ -22,13 +22,13 @@ module Codeowners
       option :autocommit, default: false, type: :boolean, aliases: '-c'
       desc 'check REPO', 'Checks .github/CODEOWNERS consistency'
       # for pre-commit: --from HEAD --to index
-      def check(repo = '.')
+      def check(repo = '.') # rubocop:disable Metrics/MethodLength
         @content_changed = false
         @repo = repo
         setup_checker
         @owners_list_handler = OwnersListHandler.new
         @owners_list_handler.checker = @checker
-        @owners_list_handler.options = @options
+        @owners_list_handler.options = options
         if options[:interactive]
           interactive_mode
         else
@@ -98,7 +98,7 @@ module Codeowners
       end
 
       def add_to_codeowners_dialog(file)
-          ask(<<~QUESTION, limited_to: %w[y i q])
+        ask(<<~QUESTION, limited_to: %w[y i q])
           File added: #{file.inspect}. Add owner to the CODEOWNERS file?
           (y) yes
           (i) ignore
@@ -180,7 +180,7 @@ module Codeowners
       end
 
       def make_suggestion(suggestion)
-         ask(<<~QUESTION, limited_to: %w[y i e d q])
+        ask(<<~QUESTION, limited_to: %w[y i e d q])
           Replace with: #{suggestion.inspect}?
           (y) yes
           (i) ignore
@@ -200,7 +200,7 @@ module Codeowners
       end
 
       def pattern_suggest_fixing
-         ask(<<~QUESTION, limited_to: %w[i e d q])
+        ask(<<~QUESTION, limited_to: %w[i e d q])
           (e) edit the pattern
           (d) delete the pattern
           (i) ignore
@@ -226,7 +226,7 @@ module Codeowners
       end
 
       def unrecognized_line_suggest_fixing(line)
-         ask(<<~QUESTION, limited_to: %w[y i d])
+        ask(<<~QUESTION, limited_to: %w[y i d])
           #{line.to_s.inspect} is in unrecognized format. Would you like to edit?
           (y) yes
           (i) ignore
@@ -237,7 +237,7 @@ module Codeowners
       def unrecognized_line_new_line
         line = nil
         loop do
-          new_line_string =  ask('New line: ')
+          new_line_string = ask('New line: ')
           line = Codeowners::Checker::Group::Line.build(new_line_string)
           break unless line.is_a?(Codeowners::Checker::Group::UnrecognizedLine)
         end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -13,6 +13,8 @@ module Codeowners
   module Cli
     # Command Line Interface used by bin/codeowners-checker.
     class Main < Base # rubocop:disable Metrics/ClassLength
+      include InteractiveHelpers
+      
       option :from, default: 'origin/master'
       option :to, default: 'HEAD'
       option :interactive, default: true, type: :boolean, aliases: '-i'
@@ -26,6 +28,7 @@ module Codeowners
         setup_checker
         @owners_list_handler = OwnersListHandler.new
         @owners_list_handler.checker = @checker
+        @owners_list_handler.options = @options
         if options[:interactive]
           interactive_mode
         else
@@ -95,7 +98,7 @@ module Codeowners
       end
 
       def add_to_codeowners_dialog(file)
-        ask(<<~QUESTION, limited_to: %w[y i q])
+          ask(<<~QUESTION, limited_to: %w[y i q])
           File added: #{file.inspect}. Add owner to the CODEOWNERS file?
           (y) yes
           (i) ignore
@@ -177,7 +180,7 @@ module Codeowners
       end
 
       def make_suggestion(suggestion)
-        ask(<<~QUESTION, limited_to: %w[y i e d q])
+         ask(<<~QUESTION, limited_to: %w[y i e d q])
           Replace with: #{suggestion.inspect}?
           (y) yes
           (i) ignore
@@ -197,7 +200,7 @@ module Codeowners
       end
 
       def pattern_suggest_fixing
-        ask(<<~QUESTION, limited_to: %w[i e d q])
+         ask(<<~QUESTION, limited_to: %w[i e d q])
           (e) edit the pattern
           (d) delete the pattern
           (i) ignore
@@ -206,7 +209,7 @@ module Codeowners
       end
 
       def pattern_change(line)
-        new_pattern = ask("Replace pattern #{line.pattern.inspect} with: ")
+        new_pattern =  ask("Replace pattern #{line.pattern.inspect} with: ")
         return if new_pattern.empty?
 
         line.pattern = new_pattern
@@ -223,7 +226,7 @@ module Codeowners
       end
 
       def unrecognized_line_suggest_fixing(line)
-        ask(<<~QUESTION, limited_to: %w[y i d])
+         ask(<<~QUESTION, limited_to: %w[y i d])
           #{line.to_s.inspect} is in unrecognized format. Would you like to edit?
           (y) yes
           (i) ignore
@@ -234,26 +237,13 @@ module Codeowners
       def unrecognized_line_new_line
         line = nil
         loop do
-          new_line_string = ask('New line: ')
+          new_line_string =  ask('New line: ')
           line = Codeowners::Checker::Group::Line.build(new_line_string)
           break unless line.is_a?(Codeowners::Checker::Group::UnrecognizedLine)
         end
         @content_changed = true
         line
       end
-
-      def ask(message, *opts)
-        return unless options[:interactive]
-
-        super
-      end
-
-      def yes?(message, *opts)
-        return unless options[:interactive]
-
-        super
-      end
-
       LABELS = {
         missing_ref: 'No owner defined',
         useless_pattern: 'Useless patterns',

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -26,9 +26,9 @@ module Codeowners
         @content_changed = false
         @repo = repo
         setup_checker
-        @owners_list_handler = OwnersListHandler.new
+        @owners_list_handler = OwnersListHandler.new(args, options)
         @owners_list_handler.checker = @checker
-        @owners_list_handler.options = options
+
         if options[:interactive]
           interactive_mode
         else

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -10,7 +10,6 @@ module Codeowners
     class OwnersListHandler < Base
       include InteractiveHelpers
 
-      attr_accessor :options
       attr_writer :checker
       attr_reader :content_changed
       default_task :fetch

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -2,11 +2,15 @@
 
 require_relative '../checker'
 require_relative '../checker/owners_list'
+require_relative 'interactive_helpers'
 
 module Codeowners
   module Cli
     # Command Line Interface dealing with OWNERS generation and validation
     class OwnersListHandler < Base
+      include InteractiveHelpers
+
+      attr_accessor :options
       attr_writer :checker
       attr_reader :content_changed
       default_task :fetch


### PR DESCRIPTION
Hey everyone,

The "codeowners-checker check --no-interactive" command was asking for user input even though it shouldn't. The default behavior would be just to run an analysis of the CODEOWNERS, OWNERS, and files and output a result to warning about file consistency in the declared patterns and owners.

This PR fixes the issue where the CLI methods for 'ask' & 'yes' are properly referenced in the classes which use them.

To test the fix:
- pull in this branch
- install the gem and reference it as a local gem in any project which uses git
- create a new file, stage it, commit it in the chosen project
- run 'codeowners-checker  config' to set a default owner
- run 'codeowners-checker check --no-interactive' and it should warn you about inconsistency