### PR TITLE
Remember ignored invalid owner for a session

### DIFF
--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -46,6 +46,14 @@ module Codeowners
 
       def interactive_mode
         @checker.fix!
+
+        if @owners_list_handler.ignored_owners.any?
+          puts 'Ignored owners: '
+          @owners_list_handler.ignored_owners.each do |owner|
+            puts " * #{owner}"
+          end
+        end
+
         return unless content_changed
 
         write_changes

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -36,12 +36,12 @@ module Codeowners
         end
 
         def suggest_add_to_owners_list(line, owner)
-          return nil if @ignored_owners.include?(owner)
+          return nil if ignored_owners.include?(owner)
 
           case add_to_ownerslist_dialog(line, owner)
           when 'y' then add_to_ownerslist(owner)
           when 'i'
-            @ignored_owners << owner
+            ignored_owners << owner
             nil
           when 'q' then throw :user_quit
           end

--- a/spec/codeowners/cli/owners_list_handler_spec.rb
+++ b/spec/codeowners/cli/owners_list_handler_spec.rb
@@ -113,9 +113,11 @@ RSpec.describe Codeowners::Cli::OwnersListHandler do
       allow(checker).to receive(:owners_list).and_return(owners_list)
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
-    def self.test_with_non_ignored_owner
+    shared_examples 'provided owner is not ignored' do
+      before do
+        owners_list_handler.ignored_owners.push(*original_ignored_owners)
+      end
+
       it 'suggest owner addition' do
         allow(owners_list_handler).to receive(:ask)
 
@@ -159,25 +161,18 @@ RSpec.describe Codeowners::Cli::OwnersListHandler do
         expect(owners_list_handler.ignored_owners).not_to include(the_owner)
       end
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
 
-    # rubocop:disable RSpec/EmptyExampleGroup
     context 'when ignored owners list is empty' do
-      before do
+      it_behaves_like 'provided owner is not ignored' do
+        let(:original_ignored_owners) { [] }
       end
-
-      test_with_non_ignored_owner
     end
 
     context 'when ignored owners list does not contain provided owner' do
-      before do
-        owners_list_handler.ignored_owners.push(another_owner1, another_owner2)
+      it_behaves_like 'provided owner is not ignored' do
+        let(:original_ignored_owners) { [another_owner1, another_owner2] }
       end
-
-      test_with_non_ignored_owner
     end
-    # rubocop:enable RSpec/EmptyExampleGroup
 
     context 'when ignore owners list contains provided owner' do
       let(:original_ignored_owners) { [another_owner1, the_owner, another_owner2] }

--- a/spec/codeowners/cli/owners_list_handler_spec.rb
+++ b/spec/codeowners/cli/owners_list_handler_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Codeowners::Cli::OwnersListHandler do
+  let(:owners_list_handler) { described_class.new }
+
+  describe '#suggest_add_to_owners_list' do
+    let(:new_file) { 'test.rb' }
+    let(:the_owner) { '@owner1' }
+    let(:another_owner1) { '@owner2' }
+    let(:another_owner2) { '@owner3' }
+    let(:line_str) { "#{new_file} #{the_owner}" }
+    let(:line) { Codeowners::Checker::Group::Line.build(line_str) }
+
+    before do
+      allow(owners_list_handler).to receive(:add_to_ownerslist_dialog)
+    end
+
+    context 'when ignored list is empty' do
+      it 'calls #add_to_ownerslist_dialog' do
+        owners_list_handler.suggest_add_to_owners_list(line, the_owner)
+
+        expect(owners_list_handler).to have_received(:add_to_ownerslist_dialog).with(line, the_owner)
+      end
+    end
+
+    context 'when ignored list contains provided owner' do
+      let(:ingored_owners) { [another_owner1, the_owner] }
+
+      before do
+        allow(owners_list_handler).to receive(:ignored_owners).and_return(ingored_owners)
+      end
+
+      it 'does not call #add_to_ownerslist_dialog and return nil' do
+        output = owners_list_handler.suggest_add_to_owners_list(line, the_owner)
+
+        expect(output).to be_nil
+        expect(owners_list_handler).not_to have_received(:add_to_ownerslist_dialog).with(line, the_owner)
+      end
+    end
+
+    context 'when ignored list does not contain provided owner' do
+      let(:ingored_owners) { [another_owner1, another_owner2] }
+
+      before do
+        allow(owners_list_handler).to receive(:ignored_owners).and_return(ingored_owners)
+      end
+
+      it 'calls #add_to_ownerslist_dialog' do
+        owners_list_handler.suggest_add_to_owners_list(line, the_owner)
+
+        expect(owners_list_handler).to have_received(:add_to_ownerslist_dialog).with(line, the_owner)
+      end
+    end
+
+    context 'when user chooses to ignore owner' do
+      before do
+        allow(owners_list_handler).to receive(:add_to_ownerslist_dialog).and_return('i')
+      end
+
+      it 'adds it to ignored_owners and returns nil' do
+        output = owners_list_handler.suggest_add_to_owners_list(line, the_owner)
+
+        expect(output).to be_nil
+        expect(owners_list_handler.ignored_owners).to include(the_owner)
+      end
+    end
+
+    context 'when user chooses to add owner' do
+      before do
+        allow(owners_list_handler).to receive(:add_to_ownerslist)
+        allow(owners_list_handler).to receive(:add_to_ownerslist_dialog).and_return('y')
+      end
+
+      it 'calls #add_to_ownerslist and does not add it to ignored_owners' do
+        owners_list_handler.suggest_add_to_owners_list(line, the_owner)
+
+        expect(owners_list_handler).to have_received(:add_to_ownerslist).with(the_owner)
+        expect(owners_list_handler.ignored_owners).not_to include(the_owner)
+      end
+    end
+
+    context 'when user chooses to quit' do
+      before do
+        allow(owners_list_handler).to receive(:add_to_ownerslist_dialog).and_return('q')
+      end
+
+      it 'throws :user_quit and does not add it to ignored_owners' do
+        expect { owners_list_handler.suggest_add_to_owners_list(line, the_owner) }.to throw_symbol :user_quit
+        expect(owners_list_handler.ignored_owners).not_to include(the_owner)
+      end
+    end
+  end
+end

--- a/spec/codeowners/cli/owners_list_handler_spec.rb
+++ b/spec/codeowners/cli/owners_list_handler_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Codeowners::Cli::OwnersListHandler do
     end
 
     context 'when ignored list contains provided owner' do
-      let(:ingored_owners) { [another_owner1, the_owner] }
+      let(:ignored_owners) { [another_owner1, the_owner] }
 
       before do
-        allow(owners_list_handler).to receive(:ignored_owners).and_return(ingored_owners)
+        allow(owners_list_handler).to receive(:ignored_owners).and_return(ignored_owners)
       end
 
       it 'does not call #add_to_ownerslist_dialog and return nil' do
@@ -39,10 +39,10 @@ RSpec.describe Codeowners::Cli::OwnersListHandler do
     end
 
     context 'when ignored list does not contain provided owner' do
-      let(:ingored_owners) { [another_owner1, another_owner2] }
+      let(:ignored_owners) { [another_owner1, another_owner2] }
 
       before do
-        allow(owners_list_handler).to receive(:ignored_owners).and_return(ingored_owners)
+        allow(owners_list_handler).to receive(:ignored_owners).and_return(ignored_owners)
       end
 
       it 'calls #add_to_ownerslist_dialog' do


### PR DESCRIPTION
Now if invalid user is ignored that is remembered for the session and all ignored users are printed out at the end.

Only affects interactive mode.