### PR TITLE
[BT-311] option to rename invalid owner

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -102,8 +102,8 @@ module Codeowners
     end
 
     def commit_changes!
-      @git.add(@codeowners.filename)
-      @git.add(@owners_list.filename)
+      @git.add(File.realpath(@codeowners.filename))
+      @git.add(File.realpath(@owners_list.filename))
       @git.commit('Fix pattern :robot:')
     end
 

--- a/lib/codeowners/checker/group/pattern.rb
+++ b/lib/codeowners/checker/group/pattern.rb
@@ -26,6 +26,11 @@ module Codeowners
           owners.first
         end
 
+        def rename_owner(owner, new_owner)
+          owners.delete(owner)
+          owners << new_owner unless owners.include?(new_owner)
+        end
+
         # Parse the line counting whitespaces between pattern and owners.
         def parse(line)
           @pattern, *@owners = line.split(/\s+/)

--- a/lib/codeowners/checker/owners_list.rb
+++ b/lib/codeowners/checker/owners_list.rb
@@ -54,6 +54,8 @@ module Codeowners
       end
 
       def <<(owner)
+        return if @owners.include?(owner)
+
         @owners << owner
       end
     end

--- a/lib/codeowners/cli/wizards/new_owner_wizard.rb
+++ b/lib/codeowners/cli/wizards/new_owner_wizard.rb
@@ -39,6 +39,7 @@ module Codeowners
           owner = nil
           loop do
             owner = ask('New owner: ')
+            owner = '@' + owner unless owner[0] == '@'
             break if @owners_list.valid_owner?(owner)
           end
           owner

--- a/lib/codeowners/cli/wizards/new_owner_wizard.rb
+++ b/lib/codeowners/cli/wizards/new_owner_wizard.rb
@@ -10,9 +10,14 @@ module Codeowners
       class NewOwnerWizard
         include InteractiveOps
 
-        def suggest_adding(line, new_owner)
+        def initialize(owners_list)
+          @owners_list = owners_list
+        end
+
+        def suggest_fixing(line, new_owner)
           case prompt(line, new_owner)
           when 'y' then :add
+          when 'r' then [:rename, keep_asking_until_valid_owner]
           when 'i' then :ignore
           when 'q' then :quit
           end
@@ -21,12 +26,22 @@ module Codeowners
         private
 
         def prompt(line, new_owner)
-          ask(<<~QUESTION, limited_to: %w[y i q])
+          ask(<<~QUESTION, limited_to: %w[y r i q])
             Unknown owner: #{new_owner} for pattern: #{line.pattern}. Add owner to the OWNERS file?
             (y) yes
+            (r) rename owner
             (i) ignore owner in this session
             (q) quit and save
           QUESTION
+        end
+
+        def keep_asking_until_valid_owner
+          owner = nil
+          loop do
+            owner = ask('New owner: ')
+            break if @owners_list.valid_owner?(owner)
+          end
+          owner
         end
       end
     end

--- a/spec/codeowners/checker/owners_list_spec.rb
+++ b/spec/codeowners/checker/owners_list_spec.rb
@@ -3,7 +3,7 @@
 require 'codeowners/checker/owners_list'
 
 RSpec.describe Codeowners::Checker::OwnersList do
-  subject { described_class.new(folder_name) }
+  subject(:owner_list) { described_class.new(folder_name) }
 
   let(:folder_name) { 'project' }
 
@@ -35,41 +35,50 @@ RSpec.describe Codeowners::Checker::OwnersList do
 
   describe '#valid_owner?' do
     before do
-      subject.owners
+      owner_list.owners
     end
 
     context 'when load OWNERS' do
       it 'validates owner from file' do
-        expect(subject).to be_valid_owner('@owner1')
-        expect(subject).not_to be_valid_owner('@unknown')
+        expect(owner_list).to be_valid_owner('@owner1')
+        expect(owner_list).not_to be_valid_owner('@unknown')
       end
     end
 
     context 'when skip owner validation' do
       before do
-        subject.validate_owners = false
+        owner_list.validate_owners = false
       end
 
       it 'returns true' do
-        expect(subject).to be_valid_owner('@unknown')
+        expect(owner_list).to be_valid_owner('@unknown')
       end
     end
   end
 
   describe '#persist!' do
     before do
-      subject.owners = []
+      owner_list.owners = []
     end
 
     context 'when new user is added to owners_list' do
       before do
-        subject.owners << '@new_owner'
-        subject.persist!
+        owner_list.owners << '@new_owner'
+        owner_list.persist!
       end
 
       it 'writes the user to OWNERS' do
         expect(File.read(subject.filename)).to eq("@new_owner\n")
       end
+    end
+  end
+
+  describe '#<<' do
+    it 'deduplicate owners' do
+      owner_list.owners = []
+      owner_list << '@new_owner'
+      owner_list << '@new_owner'
+      expect(owner_list.owners).to contain_exactly('@new_owner')
     end
   end
 end

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Codeowners::Checker do
   let(:folder_name) { 'project' }
   let(:from) { 'HEAD' }
   let(:to) { 'HEAD' }
-  let(:git) { Git.open(folder_name, log: Logger.new(STDOUT)) }
+  let(:git) { Git.open(folder_name, log: Logger.new(StringIO.new)) }
 
   ENV['GITHUB_TOKEN'] = nil
   ENV['GITHUB_ORGANIZATION'] = nil

--- a/spec/codeowners/cli/wizards/new_owner_wizard_spec.rb
+++ b/spec/codeowners/cli/wizards/new_owner_wizard_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
 
         expect(choice).to eq([:rename, new_owner])
       end
+
+      context 'with owner without @' do
+        let(:new_owner) { 'owner' }
+
+        it 'returns :replace' do
+          allow(wizard).to receive(:ask).with('New owner: ').and_return(new_owner)
+          expect(owners_list).to receive(:valid_owner?).and_return(true)
+          choice = wizard.suggest_fixing(line, the_owner)
+
+          expect(choice).to eq([:rename, '@owner'])
+        end
+      end
     end
 
     context 'when the user chose to ignore' do

--- a/spec/codeowners/cli/wizards/new_owner_wizard_spec.rb
+++ b/spec/codeowners/cli/wizards/new_owner_wizard_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
-  let(:wizard) { described_class.new }
+  let(:wizard) { described_class.new(owners_list) }
+  let(:owners_list) { instance_double(Codeowners::Checker::OwnersList) }
 
-  describe '#suggest_adding' do
+  describe '#suggest_fixing' do
     let(:new_file) { 'text.rb' }
     let(:the_owner) { '@owner1' }
     let(:line_str) { "#{new_file} #{the_owner}" }
@@ -11,10 +12,11 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
     let(:suggestion) { <<~QUESTION }
       Unknown owner: #{the_owner} for pattern: #{new_file}. Add owner to the OWNERS file?
       (y) yes
+      (r) rename owner
       (i) ignore owner in this session
       (q) quit and save
     QUESTION
-    let(:suggestion_options) { %w[y i q] }
+    let(:suggestion_options) { %w[y r i q] }
     let(:user_choice) { '' }
 
     before do
@@ -22,7 +24,7 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
     end
 
     it 'suggests owner addition' do
-      wizard.suggest_adding(line, the_owner)
+      wizard.suggest_fixing(line, the_owner)
 
       expect(wizard).to have_received(:ask).with(suggestion, limited_to: suggestion_options)
     end
@@ -31,9 +33,22 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
       let(:user_choice) { 'y' }
 
       it 'returns :add' do
-        choice = wizard.suggest_adding(line, the_owner)
+        choice = wizard.suggest_fixing(line, the_owner)
 
         expect(choice).to be(:add)
+      end
+    end
+
+    context 'when the user chose to replace' do
+      let(:user_choice) { 'r' }
+      let(:new_owner) { '@owner' }
+
+      it 'returns :replace' do
+        allow(wizard).to receive(:ask).with('New owner: ').and_return(new_owner)
+        expect(owners_list).to receive(:valid_owner?).and_return(true)
+        choice = wizard.suggest_fixing(line, the_owner)
+
+        expect(choice).to eq([:rename, new_owner])
       end
     end
 
@@ -41,7 +56,7 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
       let(:user_choice) { 'i' }
 
       it 'returns :ignore' do
-        choice = wizard.suggest_adding(line, the_owner)
+        choice = wizard.suggest_fixing(line, the_owner)
 
         expect(choice).to be(:ignore)
       end
@@ -51,7 +66,7 @@ RSpec.describe Codeowners::Cli::Wizards::NewOwnerWizard do
       let(:user_choice) { 'q' }
 
       it 'returns :quit' do
-        choice = wizard.suggest_adding(line, the_owner)
+        choice = wizard.suggest_fixing(line, the_owner)
 
         expect(choice).to be(:quit)
       end

--- a/spec/integration/help_mode_spec.rb
+++ b/spec/integration/help_mode_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Help' do
+  context 'when passing no args to the command' do
+    it { expect { Codeowners::Cli::Main.start([]) }.to output(/Commands:/).to_stdout }
+  end
+
+  context 'when passing the `check` command' do
+    it { expect { Codeowners::Cli::Main.start(%w[help check]) }.to output(/Usage:.*check REPO/m).to_stdout }
+  end
+
+  context 'when passing the `config` command' do
+    it { expect { Codeowners::Cli::Main.start(%w[help config]) }.to output(/Commands:/m).to_stdout }
+  end
+
+  context 'when passing the `fetch` command' do
+    it { expect { Codeowners::Cli::Main.start(%w[help fetch]) }.to output(/Commands:/m).to_stdout }
+  end
+
+  context 'when passing the `filter` command' do
+    it { expect { Codeowners::Cli::Main.start(%w[help filter]) }.to output(/Commands:/m).to_stdout }
+  end
+end


### PR DESCRIPTION
### 📜 Description

Add option to rename unknown owner 
based/depends on #71 

### 🔬 How to test
Change `CODEOWNERS` to contain user not present in `OWNERS`, then 
run `codeowners-checker check`
You'll have option to 
- (r) rename owner

### 👓 Review

- [x] Ensure the changes are covered by specs.
- [x] Test manually.

### 📋 Pre-merge checklist

- [x] The PR relates to a single subject.
- [x] Squash related commits together.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).

### 🎥 Screenshots
`codeowners-checker check`: 
<img width="729" alt="Screenshot 2019-12-10 at 17 53 59" src="https://user-images.githubusercontent.com/249655/70550466-158eea80-1b76-11ea-8055-2c720337c8a9.png">
