### PR TITLE
Suggest the right owner from the OWNERS file

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -114,7 +114,7 @@ module Codeowners
     private
 
     def invalid_owners
-      @invalid_owners ||= @owners_list.invalid_owner(codeowners)
+      @invalid_owners ||= @owners_list.invalid_owners(codeowners)
     end
 
     def results

--- a/lib/codeowners/checker/owners_list.rb
+++ b/lib/codeowners/checker/owners_list.rb
@@ -42,7 +42,7 @@ module Codeowners
         token && organization
       end
 
-      def invalid_owner(codeowners)
+      def invalid_owners(codeowners)
         return [] unless @validate_owners
 
         codeowners.each_with_object([]) do |line, acc|

--- a/lib/codeowners/cli/wizards/new_owner_wizard.rb
+++ b/lib/codeowners/cli/wizards/new_owner_wizard.rb
@@ -5,18 +5,28 @@ require_relative '../interactive_ops'
 module Codeowners
   module Cli
     module Wizards
-      # Suggests to add new owners to the owners list.
-      # Only returns decision without applying any modifications.
+      # Attempt to find a name similar to one provided in the owners list.
+      # Suggest to add new owner to the owners list.
+      # Only return decision without applying any modifications.
       class NewOwnerWizard
         include InteractiveOps
+
+        DEFAULT_OPTIONS = {
+          'a' => '(a) add a new owner',
+          'r' => '(r) rename owner',
+          'i' => '(i) ignore owner in this session',
+          'q' => '(q) quit and save'
+        }.freeze
 
         def initialize(owners_list)
           @owners_list = owners_list
         end
 
         def suggest_fixing(line, new_owner)
-          case prompt(line, new_owner)
-          when 'y' then :add
+          suggested_owner = suggest_name_from_owners_list(new_owner)
+          case prompt(line, new_owner, suggested_owner)
+          when 'y' then [:rename, suggested_owner]
+          when 'a' then :add
           when 'r' then [:rename, keep_asking_until_valid_owner]
           when 'i' then :ignore
           when 'q' then :quit
@@ -25,24 +35,46 @@ module Codeowners
 
         private
 
-        def prompt(line, new_owner)
-          ask(<<~QUESTION, limited_to: %w[y r i q])
-            Unknown owner: #{new_owner} for pattern: #{line.pattern}. Add owner to the OWNERS file?
-            (y) yes
-            (r) rename owner
-            (i) ignore owner in this session
-            (q) quit and save
+        def suggest_name_from_owners_list(new_owner)
+          require 'fuzzy_match'
+          search = FuzzyMatch.new(@owners_list.owners)
+          (suggested_owner, dice, _lev) = search.find_with_score(new_owner)
+          return suggested_owner if dice && dice > 0.6
+        end
+
+        def prompt(line, new_owner, suggested_owner)
+          prompt_options = build_prompt_options(suggested_owner)
+          ask(<<~QUESTION, limited_to: prompt_options.keys)
+            #{question_body(line, new_owner, suggested_owner)}
+            #{question_options(prompt_options)}
           QUESTION
         end
 
+        def question_body(line, new_owner, suggested_owner)
+          prompt = "Unknown owner: #{new_owner} for pattern: #{line.pattern}."
+          if suggested_owner
+            prompt + " Did you mean #{suggested_owner}?"
+          else
+            prompt + ' Choose an option:'
+          end
+        end
+
+        def question_options(accepted_options)
+          accepted_options.values.join("\n")
+        end
+
+        def build_prompt_options(suggested_owner)
+          return DEFAULT_OPTIONS unless suggested_owner
+
+          { 'y' => "(y) correct to #{suggested_owner}" }.merge(DEFAULT_OPTIONS)
+        end
+
         def keep_asking_until_valid_owner
-          owner = nil
           loop do
             owner = ask('New owner: ')
             owner = '@' + owner unless owner[0] == '@'
-            break if @owners_list.valid_owner?(owner)
+            return owner if @owners_list.valid_owner?(owner)
           end
-          owner
         end
       end
     end


### PR DESCRIPTION
Give user a suggestion to fix the misspelled username in `CODEOWNERS` (e.g. `@foobar` instead of `@foobaz`) by suggesting the matching one from the `OWNERS` file.

**The new behaviour** (when an owner is found in `OWNERS` file):

```bash
Unknown owner: @foobar for pattern: lib/some_file.rb. Did you mean @foobaz?
(y) correct to @foobaz
(a) add a new owner
(r) rename owner
(i) ignore owner in this session
(q) quit and save
 [c, a, r, i, q]
```

**The new behaviour** (when an owner was not found in `OWNERS` file):

```bash
Unknown owner: @foobar for pattern: lib/some_file.rb. Add owner to the OWNERS file?
(a) add a new owner
(r) rename owner
(i) ignore owner in this session
(q) quit and save
 [c, a, r, i, q]
```

**Previously was**:

```bash
Unknown owner: @foobar for pattern: lib/codeowners/cli/wizards/new_owner_wizard.rb. Add owner to the OWNERS file?
(y) yes
(r) rename owner
(i) ignore owner in this session
(q) quit and save
 [y, r, i, q] 
```