### PR TITLE
Fixes README.md instruction to use rake with bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Or you can filter any owner as a parameter:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
While following the Development instructions I found a problem when running `rake spec`, as I don't have the git ruby gem installed globally and it resulted in an error. Using `bundle exec rake spec` instead got it to work, and I opened this PR to fix the command instruction.