### PR TITLE
[BT-313] Guess GitHub organization and add configuration to override it

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codeowners-checker (1.0.5)
+    codeowners-checker (1.1.0)
       fuzzy_match (~> 2.1)
       git (~> 1.5)
       json (~> 2.1)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Example OWNERS:
 GitHub credentials are taken from the following environment variables. You might want to put them into your .bashrc or equivalent:
 
     $ export GITHUB_TOKEN='your GitHub PAT' # your personal access token from GitHub
-    $ export GITHUB_ORGANIZATION='company' # name of your GitHub organization
+
+The Github organization used to retrieve the groups/teams is automatically set according to the git remote URL. You can check and change this value using:
+
+    $ codeowners-checker config list
+    $ codeowners-checker config organization <organization>
 
 You can generate your PAT in [Settings -> Developer settings -> Personal access tokens on GitHub](https://github.com/settings/tokens) and `read:org` scope is **required**.
 

--- a/lib/codeowners/checker/owners_list.rb
+++ b/lib/codeowners/checker/owners_list.rb
@@ -15,6 +15,12 @@ module Codeowners
         @filename = CodeOwners.filename(repo).gsub('CODEOWNERS', 'OWNERS')
       end
 
+      def self.persist!(repo, owners)
+        owner_list = new(repo)
+        owner_list.owners = owners
+        owner_list.persist!
+      end
+
       def persist!
         owners_file = FileAsArray.new(@filename)
         owners_file.content = @owners

--- a/lib/codeowners/checker/owners_list.rb
+++ b/lib/codeowners/checker/owners_list.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'file_as_array'
+require_relative '../config'
 
 module Codeowners
   class Checker
@@ -9,14 +10,15 @@ module Codeowners
       attr_accessor :validate_owners, :filename
       attr_writer :owners
 
-      def initialize(repo)
+      def initialize(repo, _config = nil)
         @validate_owners = true
         # doing gsub here ensures the files are always in the same directory
         @filename = CodeOwners.filename(repo).gsub('CODEOWNERS', 'OWNERS')
+        @config ||= Codeowners::Config.new
       end
 
-      def self.persist!(repo, owners)
-        owner_list = new(repo)
+      def self.persist!(repo, owners, config = nil)
+        owner_list = new(repo, config)
         owner_list.owners = owners
         owner_list.persist!
       end
@@ -36,7 +38,7 @@ module Codeowners
 
         @owners ||=
           if github_credentials_exist?
-            Codeowners::GithubFetcher.get_owners(ENV['GITHUB_ORGANIZATION'], ENV['GITHUB_TOKEN'])
+            Codeowners::GithubFetcher.get_owners(@config.default_organization, ENV['GITHUB_TOKEN'])
           else
             FileAsArray.new(@filename).content
           end
@@ -44,8 +46,8 @@ module Codeowners
 
       def github_credentials_exist?
         token = ENV['GITHUB_TOKEN']
-        organization = ENV['GITHUB_ORGANIZATION']
-        token && organization
+        organization = @config.default_organization
+        token && !organization.empty?
       end
 
       def invalid_owners(codeowners)

--- a/lib/codeowners/checker/version.rb
+++ b/lib/codeowners/checker/version.rb
@@ -2,6 +2,6 @@
 
 module Codeowners
   class Checker
-    VERSION = '1.0.5'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/codeowners/cli/base.rb
+++ b/lib/codeowners/cli/base.rb
@@ -3,6 +3,7 @@
 require 'thor'
 
 require_relative '../config'
+require_relative 'warner'
 
 module Codeowners
   module Cli
@@ -13,6 +14,7 @@ module Codeowners
       def initialize(args = [], options = {}, config = {})
         super
         @config ||= config[:config] || default_config
+        Warner.check_warnings
       end
 
       private

--- a/lib/codeowners/cli/config.rb
+++ b/lib/codeowners/cli/config.rb
@@ -8,10 +8,10 @@ module Codeowners
     class Config < Base
       default_task :list
 
-      desc 'list', 'List the default owner configured in the config file'
+      desc 'list', 'List the default values configured in the config file'
       def list
         puts(config.to_h.map { |name, value| "#{name}: #{value.inspect}" })
-        help_stderr if config.default_owner.empty?
+        help_stderr if config.default_owner.empty? || config.default_organization.empty?
       end
 
       desc 'owner <name>', 'Configure a default owner name'

--- a/lib/codeowners/cli/config.rb
+++ b/lib/codeowners/cli/config.rb
@@ -19,6 +19,12 @@ module Codeowners
         config.default_owner = name
         puts "Default owner configured to #{name}"
       end
+
+      desc 'organization <name>', 'Configure a default organization name'
+      def organization(name)
+        config.default_organization = name
+        puts "Default organization configured to #{name}"
+      end
     end
   end
 end

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -8,22 +8,24 @@ module Codeowners
     class OwnersListHandler < Base
       default_task :fetch
 
+      FETCH_OWNER_MESSAGE = 'Fetching owners list from GitHub ...'
+      ASK_GITHUB_ORGANIZATION = 'GitHub organization (e.g. github): '
+      ASK_GITHUB_TOKEN = 'Enter GitHub token: '
+
       desc 'fetch [REPO]', 'Fetches .github/OWNERS based on github organization'
       def fetch(repo = '.')
         @repo = repo
         owners = owners_from_github
-        owners_list = Checker::OwnersList.new(repo)
-        owners_list.owners = owners
-        owners_list.persist!
+        Checker::OwnersList.persist!(repo, owners)
       end
 
       no_commands do
         def owners_from_github
           organization = ENV['GITHUB_ORGANIZATION']
-          organization ||= ask('GitHub organization (e.g. github): ')
+          organization ||= ask(ASK_GITHUB_ORGANIZATION)
           token = ENV['GITHUB_TOKEN']
-          token ||= ask('Enter GitHub token: ', echo: false)
-          puts 'Fetching owners list from GitHub ...'
+          token ||= ask(ASK_GITHUB_TOKEN, echo: false)
+          puts FETCH_OWNER_MESSAGE
           Codeowners::GithubFetcher.get_owners(organization, token)
         end
       end

--- a/lib/codeowners/cli/owners_list_handler.rb
+++ b/lib/codeowners/cli/owners_list_handler.rb
@@ -21,8 +21,8 @@ module Codeowners
 
       no_commands do
         def owners_from_github
-          organization = ENV['GITHUB_ORGANIZATION']
-          organization ||= ask(ASK_GITHUB_ORGANIZATION)
+          organization = config.default_organization
+          organization = ask(ASK_GITHUB_ORGANIZATION) if organization.empty?
           token = ENV['GITHUB_TOKEN']
           token ||= ask(ASK_GITHUB_TOKEN, echo: false)
           puts FETCH_OWNER_MESSAGE

--- a/lib/codeowners/cli/warner.rb
+++ b/lib/codeowners/cli/warner.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Codeowners
+  module Cli
+    # Checks and prints deprecation warnings.
+    module Warner
+      class << self
+        def check_warnings
+          check_github_env
+        end
+
+        def warn(msg)
+          puts "[WARNING] #{msg}"
+        end
+
+        protected
+
+        def check_github_env
+          return if ENV['GITHUB_ORGANIZATION'].nil? || ENV['GITHUB_ORGANIZATION'].empty?
+
+          warn 'Usage of GITHUB_ORGANIZATION ENV variable has been deprecated.'\
+            'Run `codeowners-checker config organization #{organization}` instead.'
+        end
+      end
+    end
+  end
+end

--- a/lib/codeowners/config.rb
+++ b/lib/codeowners/config.rb
@@ -40,10 +40,34 @@ module Codeowners
       @git.config('user.owner', name)
     end
 
+    def default_organization
+      config_org = @git.config('user.organization')
+      return config_org.strip unless config_org.nil? || config_org.strip.empty?
+
+      parse_organization_from_origin
+    end
+
+    def default_organization=(name)
+      @git.config('user.organization', name)
+    end
+
     def to_h
       {
-        default_owner: default_owner
+        default_owner: default_owner,
+        default_organization: default_organization
       }
+    end
+
+    protected
+
+    def parse_organization_from_origin
+      origin_url = @git.config('remote.origin.url')
+      return '' if origin_url.nil? || origin_url.strip.empty?
+
+      org_regexp = origin_url.match(%r{:(?<org>.+?)/})
+      return '' if org_regexp.nil? || org_regexp[:org].strip.empty?
+
+      org_regexp[:org].strip
     end
   end
 end

--- a/lib/codeowners/config.rb
+++ b/lib/codeowners/config.rb
@@ -44,7 +44,7 @@ module Codeowners
       config_org = @git.config('user.organization')
       return config_org.strip unless config_org.nil? || config_org.strip.empty?
 
-      parse_organization_from_origin
+      parse_organization_from_origin || ''
     end
 
     def default_organization=(name)
@@ -62,10 +62,10 @@ module Codeowners
 
     def parse_organization_from_origin
       origin_url = @git.config('remote.origin.url')
-      return '' if origin_url.nil? || origin_url.strip.empty?
+      return if origin_url.nil? || origin_url.strip.empty?
 
-      org_regexp = origin_url.match(%r{:(?<org>.+?)/})
-      return '' if org_regexp.nil? || org_regexp[:org].strip.empty?
+      org_regexp = origin_url.match(%r{^https?://.+?/(?<org>.+?)/|:(?<org>.+?)/})
+      return if org_regexp.nil? || org_regexp[:org].strip.empty?
 
       org_regexp[:org].strip
     end

--- a/spec/codeowners/checker/file_as_array_spec.rb
+++ b/spec/codeowners/checker/file_as_array_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Codeowners::Checker::FileAsArray do
   let!(:tmp_dir) { Dir.mktmpdir }
   let(:file_path) { File.join(tmp_dir, 'test.txt') }
 
-  after { FileUtils.rm_rf(tmp_dir) }
+  after { remove_dir(tmp_dir) }
 
   describe '#content' do
     context 'when the file exist' do

--- a/spec/codeowners/checker/owners_list_spec.rb
+++ b/spec/codeowners/checker/owners_list_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe Codeowners::Checker::OwnersList do
     end
   end
 
+  describe '.persist!' do
+    let(:owner_list) { instance_double(described_class.to_s) }
+    let(:owners) { '@owner' }
+
+    before do
+      allow(described_class).to receive(:new).and_return(owner_list)
+      allow(owner_list).to receive(:owners=).and_return(owners)
+      allow(owner_list).to receive(:persist!).and_return(owners)
+    end
+
+    it 'initializes, adds owners and persists the changes' do
+      expect(described_class).to receive(:new).with(folder_name)
+      expect(owner_list).to receive(:owners=).with(owners)
+      expect(owner_list).to receive(:persist!).with(no_args)
+      described_class.persist!(folder_name, owners)
+    end
+  end
+
   describe '#<<' do
     it 'deduplicate owners' do
       owner_list.owners = []

--- a/spec/codeowners/checker/owners_list_spec.rb
+++ b/spec/codeowners/checker/owners_list_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe Codeowners::Checker::OwnersList do
   let(:env_token) { nil }
   let(:default_organization) { '' }
 
-  around { |example| with_env('GITHUB_TOKEN' => env_token) { example.run } }
-
   before do
+    ENV['GITHUB_TOKEN'] = env_token
     allow(config).to receive(:default_organization).and_return(default_organization)
     on_dirpath(folder_name) { setup_owners_list('OWNERS') }
   end

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Codeowners::Checker do
   let(:to) { 'HEAD' }
   let(:git) { Git.open(folder_name, log: Logger.new(StringIO.new)) }
 
-  around { |example| with_env('GITHUB_TOKEN' => nil) }
-
   def setup_project_folder
     on_dirpath(folder_name) do
       setup_code_owners

--- a/spec/codeowners/cli/base_spec.rb
+++ b/spec/codeowners/cli/base_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe Codeowners::Cli::Base do
+  subject(:cli) { described_class.new }
+
+  describe 'initialization' do
+    it 'checks for warnings' do
+      expect(Codeowners::Cli::Warner).to receive(:check_warnings)
+      cli
+    end
+  end
+end

--- a/spec/codeowners/cli/config_spec.rb
+++ b/spec/codeowners/cli/config_spec.rb
@@ -63,11 +63,37 @@ RSpec.describe Codeowners::Cli::Config do
   end
 
   describe '#owner' do
-    it 'config the owner in the git config file' do
-      expect(git_config).to receive(:default_owner=).with('@owner1')
+    let(:new_owner) { '@owner1' }
+
+    before do
+      allow(git_config).to receive(:default_owner=)
+    end
+
+    it 'changes the owner in the git config file' do
+      expect(git_config).to receive(:default_owner=).with(new_owner)
+      cli.owner(new_owner)
+    end
+
+    it 'outputs success message' do
       expect do
-        cli.owner('@owner1')
+        cli.owner(new_owner)
       end.to output("Default owner configured to @owner1\n").to_stdout
+    end
+  end
+
+  describe '#organization' do
+    let(:new_org) { '@new-org' }
+
+    it 'changes the organization in the git config file' do
+      expect(git_config).to receive(:default_organization=).with(new_org)
+      cli.organization(new_org)
+    end
+
+    it 'outputs success message' do
+      allow(git_config).to receive(:default_organization=)
+      expect do
+        cli.organization(new_org)
+      end.to output("Default organization configured to @new-org\n").to_stdout
     end
   end
 end

--- a/spec/codeowners/cli/config_spec.rb
+++ b/spec/codeowners/cli/config_spec.rb
@@ -12,20 +12,53 @@ RSpec.describe Codeowners::Cli::Config do
   let(:config) { { config: git_config } }
 
   describe '#list' do
-    it 'fetch the owner from git config and show it' do
-      expect(cli).not_to receive(:help)
-      expect(git_config).to receive(:default_owner).and_return('@owner1').twice
-      expect do
-        cli.list
-      end.to output("default_owner: \"@owner1\"\n").to_stdout
+    before do
+      allow(git_config).to receive(:default_owner).and_return(default_owner)
+      allow(git_config).to receive(:default_organization).and_return(default_organization)
     end
 
-    it 'asks to provide a proper owner name' do
-      expect(cli).to receive(:help)
-      expect(git_config).to receive(:default_owner).and_return('').twice
-      expect do
+    let(:default_owner) { '@owner1' }
+    let(:default_organization) { 'toptal' }
+
+    context 'with owner and organization' do
+      it 'fetches the owner from git config and shows it' do
+        expect { cli.list }.to output(/default_owner: "@owner1"\n/).to_stdout
+      end
+
+      it 'fetches the organization from git config and shows it' do
+        expect { cli.list }.to output(/default_organization: "toptal"\n/).to_stdout
+      end
+
+      it 'does not print help' do
+        expect(cli).not_to receive(:help)
         cli.list
-      end.to output("default_owner: \"\"\n").to_stdout
+      end
+    end
+
+    context 'without owner name' do
+      let(:default_owner) { '' }
+
+      it 'prints help' do
+        expect(cli).to receive(:help)
+        cli.list
+      end
+
+      it 'shows empty owner' do
+        expect { cli.list }.to output(/default_owner: ""\n/).to_stdout
+      end
+    end
+
+    context 'without organization name' do
+      let(:default_organization) { '' }
+
+      it 'prints help' do
+        expect(cli).to receive(:help)
+        cli.list
+      end
+
+      it 'shows empty organization' do
+        expect { cli.list }.to output(/default_organization: ""\n/).to_stdout
+      end
     end
   end
 

--- a/spec/codeowners/cli/owners_list_handler_spec.rb
+++ b/spec/codeowners/cli/owners_list_handler_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe Codeowners::Cli::OwnersListHandler do
 
   describe '#fetch' do
     before do
+      ENV['GITHUB_TOKEN'] = env_token
       allow(Codeowners::GithubFetcher).to receive(:get_owners).and_return(owners_list)
       allow(Codeowners::Checker::OwnersList).to receive(:persist!).and_return(owners_list)
     end
-
-    around { |example| with_env('GITHUB_TOKEN' => env_token) { example.run } }
 
     let(:output_message) { described_class::FETCH_OWNER_MESSAGE + "\n" }
 

--- a/spec/codeowners/cli/owners_list_handler_spec.rb
+++ b/spec/codeowners/cli/owners_list_handler_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'codeowners/cli/owners_list_handler'
+
+RSpec.describe Codeowners::Cli::OwnersListHandler do
+  subject(:cli) { described_class.new(args, options, config) }
+
+  let(:args) { [] }
+  let(:options) { {} }
+  let(:git_config) { Codeowners::Config.new(fake_git) }
+  let(:fake_git) { double }
+  let(:config) { { config: git_config } }
+  let(:owners_list) { double }
+  let(:repo) { '.' }
+  let(:fetch) { cli.fetch(repo) }
+
+  describe '#fetch' do
+    before do
+      allow(Codeowners::GithubFetcher).to receive(:get_owners).and_return(owners_list)
+      allow(Codeowners::Checker::OwnersList).to receive(:persist!).and_return(owners_list)
+    end
+
+    # stub ENV values according to examples and resets them after the test finishes
+    around do |example|
+      previous_org = ENV['GITHUB_ORGANIZATION']
+      previous_token = ENV['GITHUB_TOKEN']
+      ENV['GITHUB_ORGANIZATION'] = env_organization
+      ENV['GITHUB_TOKEN'] = env_token
+      example.run
+      ENV['GITHUB_ORGANIZATION'] = previous_org
+      ENV['GITHUB_TOKEN'] = previous_token
+    end
+
+    let(:output_message) { described_class::FETCH_OWNER_MESSAGE + "\n" }
+
+    context 'with organization and token from ENV' do
+      let(:env_organization) { 'toptal' }
+      let(:env_token) { 'xxxsecretxxx' }
+
+      it 'fetchs the owners from github' do
+        expect(Codeowners::GithubFetcher).to receive(:get_owners).with(env_organization, env_token)
+        fetch
+      end
+
+      it 'outputs progress message to stdout' do
+        expect { fetch }.to output(output_message).to_stdout
+      end
+
+      it 'persists owners' do
+        expect(Codeowners::Checker::OwnersList).to receive(:persist!).with(repo, owners_list).and_return(owners_list)
+        fetch
+      end
+    end
+
+    context 'without organization' do
+      let(:env_organization) { nil }
+      let(:env_token) { 'xxxsecretxxx' }
+      let(:asked_message) { described_class::ASK_GITHUB_ORGANIZATION + ' ' }
+      let(:asked_organization) { 'toptal' }
+
+      before do
+        allow(Thor::LineEditor).to receive(:readline).with(asked_message, {}).and_return(asked_organization)
+      end
+
+      it 'asks for an organization' do
+        expect(Thor::LineEditor).to receive(:readline).with(asked_message, {})
+        fetch
+      end
+
+      it 'fetchs the owners from github' do
+        expect(Codeowners::GithubFetcher).to receive(:get_owners).with(asked_organization, env_token)
+        fetch
+      end
+
+      it 'outputs progress message to stdout' do
+        expect { fetch }.to output(output_message).to_stdout
+      end
+
+      it 'persists owners' do
+        expect(Codeowners::Checker::OwnersList).to receive(:persist!).with(repo, owners_list).and_return(owners_list)
+        fetch
+      end
+    end
+
+    context 'without token' do
+      let(:env_organization) { 'toptal' }
+      let(:env_token) { nil }
+      let(:asked_message) { described_class::ASK_GITHUB_TOKEN + ' ' }
+      let(:asked_token) { 'xxxsecretxxx' }
+
+      before do
+        allow(Thor::LineEditor).to receive(:readline).with(asked_message, echo: false).and_return(asked_token)
+      end
+
+      it 'asks for a token' do
+        expect(Thor::LineEditor).to receive(:readline).with(asked_message, echo: false)
+        fetch
+      end
+
+      it 'fetchs the owners from github' do
+        expect(Codeowners::GithubFetcher).to receive(:get_owners).with(env_organization, asked_token)
+        fetch
+      end
+
+      it 'outputs progress message to stdout' do
+        expect { fetch }.to output(output_message).to_stdout
+      end
+
+      it 'persists owners' do
+        expect(Codeowners::Checker::OwnersList).to receive(:persist!).with(repo, owners_list).and_return(owners_list)
+        fetch
+      end
+    end
+  end
+end

--- a/spec/codeowners/cli/warner_spec.rb
+++ b/spec/codeowners/cli/warner_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Codeowners::Cli::Warner do
+  describe '.check_warnings' do
+    it 'calls warn_github_env if ENV["GITHUB_ORGANIZATION"] is set' do
+      ENV['GITHUB_ORGANIZATION'] = 'toptal'
+      expect(described_class).to receive(:warn).with(/Usage of GITHUB_ORGANIZATION ENV variable has been deprecated/)
+      described_class.check_warnings
+    end
+
+    it 'does not call warn_github_env if ENV["GITHUB_ORGANIZATION"] is not set' do
+      ENV['GITHUB_ORGANIZATION'] = ''
+      expect(described_class).not_to receive(:warn)
+    end
+
+    it 'does not call warn_github_env if ENV["GITHUB_ORGANIZATION"] is nil' do
+      ENV['GITHUB_ORGANIZATION'] = nil
+      expect(described_class).not_to receive(:warn)
+    end
+  end
+
+  describe '.warn' do
+    it 'outputs messages to stdout with a warning' do
+      expect { described_class.warn('message') }.to output("[WARNING] message\n").to_stdout
+    end
+  end
+end

--- a/spec/codeowners/config_spec.rb
+++ b/spec/codeowners/config_spec.rb
@@ -21,10 +21,85 @@ RSpec.describe Codeowners::Config do
     end
   end
 
+  describe '#default_organization' do
+    before do
+      allow(fake_git).to receive('config').with('remote.origin.url').and_return(remote_url)
+    end
+
+    let(:remote_url) { 'git@github.com:toptal/codeowners-checker.git' }
+
+    context 'without user.organization set' do
+      before do
+        allow(fake_git).to receive('config').with('user.organization').and_return(nil)
+      end
+
+      it 'calls git config and fetches remote origin information' do
+        expect(fake_git).to receive('config').with('remote.origin.url')
+        subject.default_organization
+      end
+
+      it 'guesses default organization by using the origin url' do
+        expect(subject.default_organization).to eq('toptal')
+      end
+
+      context 'with empty user.organization' do
+        before do
+          allow(fake_git).to receive('config').with('user.organization').and_return(' ')
+        end
+
+        it 'guesses default organization by using the origin url' do
+          expect(subject.default_organization).to eq('toptal')
+        end
+      end
+
+      context 'without a remote origin' do
+        let(:remote_url) { nil }
+
+        it 'returns blank string' do
+          expect(subject.default_organization).to eq('')
+        end
+      end
+
+      context 'without a parseable organization' do
+        let(:remote_url) { 'git@github.com:codeowners-checker.git' }
+
+        it 'returns blank string' do
+          expect(subject.default_organization).to eq('')
+        end
+      end
+    end
+
+    context 'with user.organization set' do
+      before do
+        allow(fake_git).to receive('config').with('user.organization').and_return('other-org')
+      end
+
+      it 'does not call git config to fetch remote origin information' do
+        expect(fake_git).not_to receive('config').with('remote.origin.url')
+        subject.default_organization
+      end
+
+      it 'uses the value set for user.organization instead of guessing' do
+        expect(subject.default_organization).to eq('other-org')
+      end
+    end
+  end
+
+  describe '#default_organization=' do
+    it 'sets default user.team from git configuration' do
+      expect(fake_git).to receive('config').with('user.organization', 'toptal')
+      subject.default_organization = 'toptal'
+    end
+  end
+
   describe '#to_h' do
+    before do
+      allow(subject).to receive(:default_owner).and_return('my-team')
+      allow(subject).to receive(:default_organization).and_return('toptal')
+    end
+
     it 'converts default_owner to a hash' do
-      expect(fake_git).to receive('config').with('user.owner').and_return('my-team')
-      expect(subject.to_h).to eq(default_owner: 'my-team')
+      expect(subject.to_h).to eq(default_owner: 'my-team', default_organization: 'toptal')
     end
   end
 end

--- a/spec/codeowners/config_spec.rb
+++ b/spec/codeowners/config_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe Codeowners::Config do
       end
     end
 
+    describe '#parse_organization_from_origin' do
+      before do
+        allow(fake_git).to receive('config').with('remote.origin.url').and_return(remote_url)
+      end
+
+      let(:parsed_org) { subject.send(:parse_organization_from_origin) }
+
+      context 'with git url' do
+        let(:remote_url) { 'git@github.com:toptal/codeowners-checker.git' }
+
+        it { expect(parsed_org).to eq('toptal') }
+      end
+
+      context 'with http url' do
+        let(:remote_url) { 'https://github.com/toptal/codeowners-checker.git' }
+
+        it { expect(parsed_org).to eq('toptal') }
+      end
+    end
+
     context 'with user.organization set' do
       before do
         allow(fake_git).to receive('config').with('user.organization').and_return('other-org')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before do
+    ENV['GITHUB_ORGANIZATION'] = ''
+    ENV['GITHUB_TOKEN'] = nil
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'pry'
-require 'fileutils'
 require 'simplecov'
 SimpleCov.start do
   add_filter 'spec'
@@ -9,11 +8,13 @@ end
 
 require 'bundler/setup'
 require 'codeowners/cli/main'
-require_relative 'support/integration_test_runner'
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 
 Dir['lib/**/*.rb'].each { |file| require file[4..-1] }
 
 RSpec.configure do |config|
+  config.include Helpers
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module Helpers
+  # stub ENV values according to examples and resets them after the test finishes
+  # this method should be used with an around block like so:
+  # around { |example| with_env('SOME' => 'VALUE') { example.run } }
+  def with_env(env)
+    previous_env = {}
+    env.each do |key, value|
+      previous_env[key] = ENV[key]
+      ENV[key] = value
+    end
+    yield
+    previous_env.each do |key, value|
+      ENV[key] = value
+    end
+  end
+
+  # Move current dir to folder and creates it if it doesn't exists
+  def on_dirpath(folder_name)
+    Dir.mkdir(folder_name) unless Dir.exist?(folder_name)
+    Dir.chdir(folder_name) do
+      yield
+    end
+  end
+
+  def create_dir(dirpath)
+    FileUtils.mkdir_p(dirpath)
+  end
+
+  def remove_dir(dirpath)
+    FileUtils.rm_r(dirpath) if Dir.exist?(dirpath)
+  end
+
+  def remove_file(filepath)
+    FileUtils.rm_f(filepath)
+  end
+
+  def move_dir(dirpath, new_dirpath)
+    FileUtils.mv(dirpath, new_dirpath)
+  end
+
+  def setup_owners_list(filename = '.github/OWNERS')
+    File.open(filename, 'w+') do |file|
+      file.puts <<~CONTENT
+        @owner
+        @owner1
+        @owner2
+      CONTENT
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,21 +3,6 @@
 require 'fileutils'
 
 module Helpers
-  # stub ENV values according to examples and resets them after the test finishes
-  # this method should be used with an around block like so:
-  # around { |example| with_env('SOME' => 'VALUE') { example.run } }
-  def with_env(env)
-    previous_env = {}
-    env.each do |key, value|
-      previous_env[key] = ENV[key]
-      ENV[key] = value
-    end
-    yield
-    previous_env.each do |key, value|
-      ENV[key] = value
-    end
-  end
-
   # Move current dir to folder and creates it if it doesn't exists
   def on_dirpath(folder_name)
     Dir.mkdir(folder_name) unless Dir.exist?(folder_name)

--- a/spec/support/integration_test_runner.rb
+++ b/spec/support/integration_test_runner.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'helpers'
+
 class IntegrationTestRunner
   include RSpec::Mocks::ExampleMethods
+  include Helpers
 
   # Silence thor warnings while setting up io listeners
   class CaptureIO < StringIO
@@ -51,9 +54,8 @@ class IntegrationTestRunner
   # rubocop: disable Metrics/MethodLength
   def setup_project
     Dir.mkdir('tmp') unless Dir.exist?('tmp')
-    FileUtils.rm_r(PROJECT_PATH) if Dir.exist?(PROJECT_PATH)
-    Dir.mkdir(PROJECT_PATH)
-    Dir.chdir(PROJECT_PATH) do
+    remove_dir(PROJECT_PATH)
+    on_dirpath(PROJECT_PATH) do
       Git.init
       git = Git.open('.', logger: Logger.new(STDOUT))
       Dir.mkdir('.github')
@@ -74,7 +76,7 @@ class IntegrationTestRunner
       unless File.exist?(file_path)
         parts = file_path.split('/')
         dir_parts = parts[0..-2]
-        FileUtils.mkdir_p(File.join(*dir_parts)) unless dir_parts.empty?
+        create_dir(File.join(*dir_parts)) unless dir_parts.empty?
       end
       File.write(file_path, content)
     end


### PR DESCRIPTION
Instead of relying on setting `ENV["GITHUB_ORGANIZATION"]`, the organization is now automatically inferred based on the remote origin URL. For example, given `git@github.com:toptal/codeowners-checker.git` as the origin URL, the guessed organization will be `toptal`. It supports remote origin URLs in both git and HTTP(S) formats from Github.

An option to override the default guessed organization is also present and can be used by invoking `codeowners-checker config organization <organization>`, and you can check the value set with `codeowners-checker config list`

A deprecation warning has also been added to warn that `ENV["GITHUB_ORGANIZATION"]` is deprecated.

## HOW TO TEST
download branch, install it with `bundle exec rake install`.

Run `codeowners-checker config list` on some repository. You should see a message saying `default_organization: "<something>"`. 

You can also `export GITHUB_ORGANIZATION=something` and verify that the warning message appears when running the previous command, but doesn't when it's set to blank

If you can see a default_organization value (it's not ""), then when running `codeowners-checker check` it should not ask for the organization, even when ENV["GITHUB_ORGANIZATION"] is not set.

You can also test that `codeowners-checker config organization new-org-name` changes the value shown by `codeowners-checker config list`

Finally, when setting the organization correctly on a project and running `codeowners-checker fetch` it should download an `OWNERS` file with the correct organization teams/contributors.

The test coverage went up from 96.88% to 98.34% and all tests should be green (tests can be run with `bundle exec rake spec`)
