### PR TITLE
Add whitelist to make introduction into a new project easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+Have a look at [spec/README.md](./spec/README.md) for more information about what tools are available when writing tests.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/toptal/codeowners-checker. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ between two git revisions.
 
 It will configure `@owner` as the default owner in the config file.
 
-If you are just starting to use `codeowners-checker` in your project, you might not have clear ownership defined for all parts of the code.  In this case using the checker would be very tedious in the beginning, as it prompts for ownership rules for all files.
+#### Whitelist
 
-You can still use `codeowners-checker` in this case without the tedium by providing a whitelist.  The whitelist contains patterns to ignore when checking files.
+If you are just starting to use `codeowners-checker` in your project, you might not have clear ownership defined for all parts of the code. In this case using the checker would be very tedious in the beginning, as it prompts for ownership rules for all files.
+
+You can still use `codeowners-checker` in this case without the tedium by providing a whitelist. The whitelist contains patterns to ignore when checking files.
 
 Just place a file called `CODEOWNERS_WHITELIST` next to your `CODEOWNERS` file to enable the whitelist.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ between two git revisions.
 
 It will configure `@owner` as the default owner in the config file.
 
+If you are just starting to use `codeowners-checker` in your project, you might not have clear ownership defined for all parts of the code.  In this case using the checker would be very tedious in the beginning, as it prompts for ownership rules for all files.
+
+You can still use `codeowners-checker` in this case without the tedium by providing a whitelist.  The whitelist contains patterns to ignore when checking files.
+
+Just place a file called `CODEOWNERS_WHITELIST` next to your `CODEOWNERS` file to enable the whitelist.
+
+Here is an example:
+
+```
+# The format of the file follows the format used by .gitignore
+
+# ignore files under bin
+bin/* 
+```
+For all operations, `codeowners-checker` will ignore files matching the patterns in here.
 
 ### Fetching and validating owners
 

--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -88,10 +88,16 @@ module Codeowners
       false
     end
 
+    def whitelist?
+      whitelist.exist?
+    end
+
+    def whitelist_filename
+      @whitelist_filename ||= CodeOwners.filename(@repo_dir) + '_WHITELIST'
+    end
+
     def whitelist
-      @whitelist ||= Whitelist.new(
-        CodeOwners.filename(@repo_dir) + '_WHITELIST'
-      )
+      @whitelist ||= Whitelist.new(whitelist_filename)
     end
 
     def codeowners

--- a/lib/codeowners/checker/whitelist.rb
+++ b/lib/codeowners/checker/whitelist.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'pathspec'
+
+module Codeowners
+  class Checker
+    # Manage CODEOWNERS_WHITELIST file reading
+    class Whitelist
+      def initialize(filename)
+        @filename = filename
+      end
+
+      def whitelisted?(filename)
+        pathspec.match(filename)
+      end
+
+      def to_proc
+        proc { |item| whitelisted?(item) }
+      end
+
+      private
+
+      def pathspec
+        @pathspec = if File.exist?(@filename)
+                      PathSpec.from_filename(@filename)
+                    else
+                      PathSpec.new([])
+                    end
+      end
+    end
+  end
+end

--- a/lib/codeowners/checker/whitelist.rb
+++ b/lib/codeowners/checker/whitelist.rb
@@ -10,6 +10,10 @@ module Codeowners
         @filename = filename
       end
 
+      def exist?
+        File.exist?(@filename)
+      end
+
       def whitelisted?(filename)
         pathspec.match(filename)
       end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -24,6 +24,9 @@ module Codeowners
       # for pre-commit: --from HEAD --to index
       def check(repo = '.')
         checker = create_checker(repo)
+        Warner.warn("No whitelist found at #{checker.whitelist_filename}") unless
+          checker.whitelist?
+
         if checker.consistent?
           Reporter.print '✅ File is consistent'
           exit 0

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,13 @@
+# Custom matchers
+
+Here's a quick overview of the matchers introduced for specs in this project.
+
+## Integration tests
+
+These matchers are available in integration specs (see [integration](./integration) directory):
+
+* `warn_with(line0, line1...)` checks that warnings containing `line0` etc have been emitted,
+* `report_with(line0, line1...)` checks that messages containing `line0` etc have been reported to the user,
+* `have_empty_report` checks that no messages have been reported to the user,
+* `ask(question)` checks that the user has been prompted for the string `question`.
+

--- a/spec/codeowners/checker/whitelist_spec.rb
+++ b/spec/codeowners/checker/whitelist_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'codeowners/checker/whitelist'
+
+RSpec.describe Codeowners::Checker::Whitelist do
+  subject { described_class.new(whitelist_filename) }
+
+  let(:folder_name) { 'project' }
+  let(:whitelisted_file)   { 'whitelisted_file.rb' }
+  let(:whitelist_filename) { '.github/CODEOWNERS_WHITELIST' }
+
+  around do |example|
+    on_dirpath(folder_name) do
+      create_dir('.github')
+      File.write('.github/CODEOWNERS_WHITELIST', whitelisted_file)
+      File.write(whitelisted_file, "# some ruby code here\n")
+      example.call
+    end
+    remove_dir(folder_name)
+  end
+
+  context 'when referring to a non-existent whitelist file' do
+    let(:whitelist_filename) { 'does-not-exist' }
+
+    it 'returns a whitelist matching nothing' do
+      expect(subject.whitelisted?('example.rb')).to be false
+    end
+  end
+
+  context 'when referring to an existing file' do
+    it 'reports true for a path listed in the whitelist' do
+      expect(subject.whitelisted?(whitelisted_file)).to be true
+    end
+  end
+
+  context 'when used as a proc' do
+    it 'returns true for whitelisted items' do
+      expect([whitelisted_file].all?(&subject)).to be true
+    end
+
+    it 'returns false for non-whitelisted items' do
+      expect(['example.rb'].all?(&subject)).to be false
+    end
+  end
+end

--- a/spec/codeowners/checker/whitelist_spec.rb
+++ b/spec/codeowners/checker/whitelist_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe Codeowners::Checker::Whitelist do
       expect(['example.rb'].all?(&subject)).to be false
     end
   end
+
+  describe '#exists?' do
+    context 'when no whitelist file exists' do
+      let(:whitelist_filename) { 'does-not-exist' }
+
+      it 'returns false' do
+        expect(subject).not_to be_exist
+      end
+    end
+
+    context 'when the whitelist file exists' do
+      it 'returns true' do
+        expect(subject).to be_exist
+      end
+    end
+  end
 end

--- a/spec/integration/report_mode_spec.rb
+++ b/spec/integration/report_mode_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe 'Report mode' do
   let(:owners) { [] }
   let(:file_tree) { {} }
 
+  context 'when no whitelist exists' do
+    let(:file_tree) { { 'lib/new_file.rb' => 'bar' } }
+
+    it { is_expected.to warn_with('No whitelist found at tmp/test-project/.github/CODEOWNERS_WHITELIST') }
+  end
+
+  context 'when a whitelist exists' do
+    let(:file_tree) { { '.github/CODEOWNERS_WHITELIST' => '# ignore files here' } }
+
+    it 'does not warn about a whitelist' do
+      expect(runner).not_to warn_with('No whitelist found at tmp/test-project/.github/CODEOWNERS_WHITELIST')
+    end
+  end
+
   context 'when no issues' do
     let(:codeowners) { ['lib/new_file.rb @mpospelov'] }
     let(:owners) { ['@mpospelov'] }

--- a/spec/support/integration_test_runner.rb
+++ b/spec/support/integration_test_runner.rb
@@ -13,7 +13,7 @@ class IntegrationTestRunner
     end
   end
 
-  Result = Struct.new(:reports, :questions)
+  Result = Struct.new(:reports, :warnings, :questions)
   PROJECT_PATH = File.join('tmp', 'test-project')
 
   def initialize(codeowners: [], owners: [], file_tree: {}, flags: [], answers: [])
@@ -23,6 +23,7 @@ class IntegrationTestRunner
     @flags = flags.tap { |f| f.push('--from=HEAD~1') }
     @answers = answers
     @reports = []
+    @warnings = []
     @questions = []
   end
 
@@ -36,7 +37,7 @@ class IntegrationTestRunner
       Codeowners::Cli::Main.start(['check', PROJECT_PATH, *flags])
     rescue SystemExit
     end
-    Result.new(@reports.flatten, @questions)
+    Result.new(@reports.flatten, @warnings, @questions)
   end
   # rubocop: enable Lint/HandleExceptions
 
@@ -85,6 +86,7 @@ class IntegrationTestRunner
   # rubocop: disable RSpec/AnyInstance
   def setup_io_listeners
     allow(Codeowners::Reporter).to receive(:print) { |*args| @reports << args }
+    allow(Codeowners::Cli::Warner).to receive(:warn) { |msg| @warnings << msg }
     allow_any_instance_of(Thor).to receive(:ask) do |_, question, limited_to|
       @questions << [question, limited_to].compact
       @answers.shift
@@ -95,6 +97,25 @@ class IntegrationTestRunner
     end
   end
   # rubocop: enable RSpec/AnyInstance
+
+  RSpec::Matchers.define :warn_with do |*expected_warnings|
+    match do |result|
+      IntegrationTestRunner.assert_matcher_input(result)
+      expected_warnings.join("\n") == result.warnings.join("\n")
+    end
+
+    failure_message do |actual|
+      <<~MSG
+        expected that the warnings:
+
+        #{actual.warnings.map { |w| "- #{w}" }.join("\n")}
+
+        will include all of:
+
+        #{expected_warnings.map { |w| "- #{w}" }.join("\n")}
+      MSG
+    end
+  end
 
   RSpec::Matchers.define :report_with do |*expected_reports|
     match do |result|

--- a/spec/support/integration_test_runner.rb
+++ b/spec/support/integration_test_runner.rb
@@ -83,6 +83,7 @@ class IntegrationTestRunner
     end
   end
 
+  # rubocop: disable Metrics/AbcSize
   # rubocop: disable RSpec/AnyInstance
   def setup_io_listeners
     allow(Codeowners::Reporter).to receive(:print) { |*args| @reports << args }
@@ -97,6 +98,7 @@ class IntegrationTestRunner
     end
   end
   # rubocop: enable RSpec/AnyInstance
+  # rubocop: enable Metrics/AbcSize
 
   RSpec::Matchers.define :warn_with do |*expected_warnings|
     match do |result|


### PR DESCRIPTION
This pull request adds a whitelist feature to the codeowners-checker.

The motivation for this feature is to allow checking only parts of a repository according to the `CODEOWNERS` file.  Using this feature, the codeowners check can be introduced gradually in a repository.

See the `README` for how this feature works.

## How to test

### No CODEOWNERS_WHITELIST file

```
mkdir .github
touch .github/CODEOWNERS
bin/codeowners-checker check --interactive=f
```

Expected output includes:

```
[WARNING] No whitelist found at ./.github/CODEOWNERS_WHITELIST
lib/codeowners/checker/whitelist.rb
spec/codeowners/checker/whitelist_spec.rb
```
### With CODEOWNERS_WHITELIST

Whitelist the newly added files:

```
$ printf "**/whitelist*.rb\n" > .github/CODEOWNERS_WHITELIST
$ bin/codeowners-checker check --interactive=f
✅ File is consistent
```

The checker should ignore the files as shown above.
