### PR TITLE
Add 'list' command to list all files owned for a given owner

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -64,6 +64,13 @@ module Codeowners
       end
     end
 
+    def list_files_for_owner(owner = '')
+      patterns = patterns_by_owner[owner]
+      patterns.each_with_object({}) do |pattern, results|
+        results[pattern] = files_for_pattern(pattern).map(&:first)
+      end
+    end
+
     def useless_pattern
       @useless_pattern ||= codeowners.select do |line|
         line.pattern? && !pattern_has_files(line.pattern)
@@ -74,8 +81,12 @@ module Codeowners
       @missing_reference ||= added_files.reject(&method(:defined_owner?))
     end
 
+    def files_for_pattern(pattern)
+      @git.ls_files(pattern.gsub(%r{^/}, '')).reject(&whitelist)
+    end
+
     def pattern_has_files(pattern)
-      @git.ls_files(pattern.gsub(%r{^/}, '')).reject(&whitelist).any?
+      files_for_pattern(pattern).any?
     end
 
     def defined_owner?(file)

--- a/lib/codeowners/cli/list.rb
+++ b/lib/codeowners/cli/list.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Codeowners
+  module Cli
+    # List files owned by the given owner
+    class List < Base
+      option :from, default: 'origin/master'
+      option :to, default: 'HEAD'
+      option :verbose, default: false, type: :boolean, aliases: '-v'
+      desc 'by <owner>', <<~DESC
+        Lists all files owned by owner.
+        If no owner is specified, default owner is taken from the config file.
+      DESC
+      # option :local, default: false, type: :boolean, aliases: '-l'
+      # option :branch, default: '', aliases: '-b'
+      def by(owner = config.default_owner)
+        return if owner.empty?
+
+        Reporter.print "Checking ownership for '#{owner}'"
+        results = checker.list_files_for_owner(owner)
+        if results
+          print_results(results)
+        else
+          Reporter.print "Owner #{owner} not defined in .github/CODEOWNERS"
+        end
+      end
+
+      def initialize(args = [], options = {}, config = {})
+        super
+        @repo_base_path = `git rev-parse --show-toplevel`
+        if !@repo_base_path || @repo_base_path.empty?
+          raise 'You must be positioned in a git repository to use this tool'
+        end
+
+        @repo_base_path.chomp!
+        Dir.chdir(@repo_base_path)
+
+        @checker ||= config[:checker] || default_checker
+      end
+
+      default_task :by
+
+      private
+
+      attr_reader :checker
+
+      def default_checker
+        Codeowners::Checker.new(@repo_base_path, options[:from], options[:to])
+      end
+
+      def print_results(results)
+        results.each do |pattern, files|
+          Reporter.print "Pattern: '#{pattern}' - matches #{files.length} file(s)"
+          if options[:verbose]
+            files.each { |name| Reporter.print "\t#{name}" }
+            Reporter.print '*' * 30
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -5,6 +5,7 @@ require_relative '../reporter'
 require_relative 'base'
 require_relative 'config'
 require_relative 'filter'
+require_relative 'list'
 require_relative 'owners_list_handler'
 require_relative '../github_fetcher'
 require_relative 'suggest_file_from_pattern'
@@ -39,6 +40,9 @@ module Codeowners
 
       desc 'filter <by-owner>', 'List owners of changed files'
       subcommand 'filter', Codeowners::Cli::Filter
+
+      desc 'list <by-owner>', 'List files owned by the given owner'
+      subcommand 'list', Codeowners::Cli::List
 
       desc 'config', 'Checks config is consistent or configure it'
       subcommand 'config', Codeowners::Cli::Config

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -439,4 +439,20 @@ RSpec.describe Codeowners::Checker do
       expect(subject.main_group).to be_a(Codeowners::Checker::Group)
     end
   end
+
+  describe '#list_files_for_owner' do
+    subject { described_class.new folder_name, from, to }
+
+    it 'does stuff' do
+      expect(subject.list_files_for_owner('@owner1')).to eq(
+        'Gemfile' => ['Gemfile'],
+        'lib/shared/*' => ['lib/shared/file.rb']
+      )
+    end
+
+    it 'returns empty results when the owner has no patterns' do
+      expect(subject.list_files_for_owner('@unknown_owner42')).to eq({})
+      expect(subject.list_files_for_owner(nil)).to eq({})
+    end
+  end
 end

--- a/spec/codeowners/cli/list_spec.rb
+++ b/spec/codeowners/cli/list_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'codeowners/cli/filter'
+
+RSpec.describe Codeowners::Cli::List do
+  subject(:cli) { described_class.new(args, options, config) }
+
+  let(:args) { [] }
+  let(:options) { {} }
+  let(:git_config) { double }
+  let(:checker) { double }
+  let(:config) { { checker: checker, config: git_config } }
+
+  before do
+    allow(checker).to receive(:list_files_for_owner).and_return(results)
+  end
+
+  describe '#by' do
+    let(:results) do
+      { 'foo/**/*.rb' => ['foo/bar.rb', 'foo/baz.rb'],
+        'bar/**/*.rb' => ['bar/foo.rb', 'bar/baz.rb'] }
+    end
+
+    context 'when filter by explicity owner' do
+      let(:args) { %w[by @owner1] }
+
+      it 'applies the user input as the filter' do
+        expect(cli).not_to receive(:default_owner)
+        expect do
+          cli.by(args.last)
+        end.to output(<<~OUTPUT).to_stdout
+          Checking ownership for '@owner1'
+          Pattern: 'foo/**/*.rb' - matches 2 file(s)
+          Pattern: 'bar/**/*.rb' - matches 2 file(s)
+        OUTPUT
+      end
+    end
+
+    context 'when do not pass any parameter' do
+      let(:args) { %w[] }
+
+      it 'applies `by` with `default_owner`' do
+        expect(git_config).to receive(:default_owner).and_return('@owner1')
+        cli.by
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a simple `list` command to verify ownership of files for a given owner.  I found this useful when making changes to CODEOWNERS in large code bases with complex rules.

example usage: `codeowners-checker list @owner1`