### PR TITLE
allow caller to disable specific checks

### DIFF
--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -16,15 +16,18 @@ module Codeowners
   # By default (:validate_owners property) it also reads OWNERS with list of all
   # possible/valid owners and validates every owner in CODEOWNERS is defined in OWNERS
   class Checker
-    attr_reader :owners_list
+    attr_reader :owners_list, :enabled_checks
+
+    ALL_CHECKS = %i[missing_ref useless_pattern invalid_owner unrecognized_line].freeze
 
     # Get repo metadata and compare with the owners
-    def initialize(repo, from, to)
+    def initialize(repo, from, to, enabled_checks = ALL_CHECKS)
       @git = Git.open(repo, log: Logger.new(IO::NULL))
       @repo_dir = repo
       @from = from || 'HEAD'
       @to = to
       @owners_list = OwnersList.new(@repo_dir)
+      @enabled_checks = enabled_checks
     end
 
     def changes_to_analyze
@@ -134,10 +137,22 @@ module Codeowners
 
     def results
       @results ||= Enumerator.new do |yielder|
-        missing_reference.each { |ref| yielder << [:missing_ref, ref] }
-        useless_pattern.each { |pattern| yielder << [:useless_pattern, pattern] }
-        invalid_owners.each { |(owner, missing)| yielder << [:invalid_owner, owner, missing] }
-        unrecognized_line.each { |line| yielder << [:unrecognized_line, line] }
+        enabled_checks.each do |check|
+          check_results(check).each { |result| yielder << result }
+        end
+      end
+    end
+
+    def check_results(check)
+      case check
+      when :missing_ref
+        missing_reference.map { |ref| [:missing_ref, ref] }
+      when :useless_pattern
+        useless_pattern.map { |pattern| [:useless_pattern, pattern] }
+      when :invalid_owner
+        invalid_owners.map { |(owner, missing)| [:invalid_owner, owner, missing] }
+      when :unrecognized_line
+        unrecognized_line.map { |line| [:unrecognized_line, line] }
       end
     end
   end

--- a/lib/codeowners/checker.rb
+++ b/lib/codeowners/checker.rb
@@ -21,13 +21,13 @@ module Codeowners
     ALL_CHECKS = %i[missing_ref useless_pattern invalid_owner unrecognized_line].freeze
 
     # Get repo metadata and compare with the owners
-    def initialize(repo, from, to, enabled_checks = ALL_CHECKS)
+    def initialize(repo:, from:, to:, checks: ALL_CHECKS)
       @git = Git.open(repo, log: Logger.new(IO::NULL))
       @repo_dir = repo
       @from = from || 'HEAD'
       @to = to
       @owners_list = OwnersList.new(@repo_dir)
-      @enabled_checks = enabled_checks
+      @enabled_checks = checks
     end
 
     def changes_to_analyze

--- a/lib/codeowners/cli/filter.rb
+++ b/lib/codeowners/cli/filter.rb
@@ -56,7 +56,7 @@ module Codeowners
       attr_reader :checker
 
       def default_checker
-        Codeowners::Checker.new(@repo_base_path, options[:from], options[:to])
+        Codeowners::Checker.new(repo: @repo_base_path, from: options[:from], to: options[:to])
       end
     end
   end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -70,7 +70,7 @@ module Codeowners
         from = options[:from]
         to = options[:to] != 'index' ? options[:to] : nil
         checks = Codeowners::Checker::ALL_CHECKS.select { |check| options[:"check_#{check}"] }
-        checker = Codeowners::Checker.new(repo, from, to, checks)
+        checker = Codeowners::Checker.new(repo: repo, from: from, to: to, checks: checks)
         checker.owners_list.validate_owners = options[:validateowners]
         checker
       end

--- a/lib/codeowners/cli/main.rb
+++ b/lib/codeowners/cli/main.rb
@@ -20,6 +20,10 @@ module Codeowners
       option :interactive, default: true, type: :boolean, aliases: '-i'
       option :validateowners, default: true, type: :boolean, aliases: '-v'
       option :autocommit, default: false, type: :boolean, aliases: '-c'
+      option :check_unrecognized_line, default: true, type: :boolean
+      option :check_useless_pattern, default: true, type: :boolean
+      option :check_missing_ref, default: true, type: :boolean
+      option :check_invalid_owner, default: true, type: :boolean
       desc 'check REPO', 'Checks .github/CODEOWNERS consistency'
       # for pre-commit: --from HEAD --to index
       def check(repo = '.')
@@ -65,7 +69,8 @@ module Codeowners
       def create_checker(repo)
         from = options[:from]
         to = options[:to] != 'index' ? options[:to] : nil
-        checker = Codeowners::Checker.new(repo, from, to)
+        checks = Codeowners::Checker::ALL_CHECKS.select { |check| options[:"check_#{check}"] }
+        checker = Codeowners::Checker.new(repo, from, to, checks)
         checker.owners_list.validate_owners = options[:validateowners]
         checker
       end

--- a/spec/codeowners/checker_spec.rb
+++ b/spec/codeowners/checker_spec.rb
@@ -3,7 +3,7 @@
 require 'codeowners/checker'
 
 RSpec.describe Codeowners::Checker do
-  subject { described_class.new(folder_name, from, to).fix!.to_a }
+  subject { described_class.new(repo: folder_name, from: from, to: to).fix!.to_a }
 
   let(:folder_name) { 'project' }
   let(:from) { 'HEAD' }
@@ -202,7 +202,7 @@ RSpec.describe Codeowners::Checker do
     end
 
     context 'when no-validateowners is used' do
-      subject { described_class.new folder_name, from, to }
+      subject { described_class.new(repo: folder_name, from: from, to: to) }
 
       before do
         subject.owners_list.validate_owners = false
@@ -310,7 +310,7 @@ RSpec.describe Codeowners::Checker do
   end
 
   describe '.patterns_by_owner' do
-    subject { described_class.new folder_name, from, to }
+    subject { described_class.new(repo: folder_name, from: from, to: to) }
 
     it 'collets patterns grouped by owner' do
       expect(subject.patterns_by_owner)
@@ -323,7 +323,7 @@ RSpec.describe Codeowners::Checker do
   end
 
   describe '.changes_with_ownership' do
-    subject { described_class.new folder_name, from, to }
+    subject { described_class.new(repo: folder_name, from: from, to: to) }
 
     it 'collets changes from a specific owner' do
       expect(subject.changes_with_ownership)
@@ -396,7 +396,7 @@ RSpec.describe Codeowners::Checker do
   end
 
   describe '#codeowners' do
-    subject { described_class.new(folder_name, from, to) }
+    subject { described_class.new(repo: folder_name, from: from, to: to) }
 
     context 'when the file is in the .github folder' do
       it 'returns the content of the codeowners file' do
@@ -429,7 +429,7 @@ RSpec.describe Codeowners::Checker do
   end
 
   describe '#main_group' do
-    subject { described_class.new(folder_name, from, to) }
+    subject { described_class.new(repo: folder_name, from: from, to: to) }
 
     it 'returns an array containing the main group' do
       expect(subject.main_group.to_content).to eq(

--- a/spec/integration/report_mode_spec.rb
+++ b/spec/integration/report_mode_spec.rb
@@ -5,9 +5,16 @@ require 'codeowners/checker'
 RSpec.describe 'Report mode' do
   subject(:runner) do
     IntegrationTestRunner
-      .new(codeowners: codeowners, owners: owners, file_tree: file_tree, flags: ['--interactive=f'])
+      .new(
+        codeowners: codeowners,
+        owners: owners,
+        file_tree: file_tree,
+        flags: ['--interactive=f'] + extra_flags
+      )
       .run
   end
+
+  let(:extra_flags) { [] }
 
   let(:codeowners) { [] }
   let(:owners) { [] }
@@ -94,6 +101,55 @@ RSpec.describe 'Report mode' do
         '------------------------------',
         '@mpospelov'
       )
+    end
+  end
+
+  context 'when all checks enabled' do
+    let(:codeowners) do
+      [
+        'file_invalid_owner @invalid_owner',
+        'useless_pattern @owner',
+        '@unrecognized_line'
+      ]
+    end
+    let(:owners) { ['@owner'] }
+    let(:file_tree) do
+      {
+        'file_missing_ref' => 'bar',
+        'file_invalid_owner' => 'baz'
+      }
+    end
+
+    context 'without invalid owner check' do
+      let(:extra_flags) { ['--no-check-invalid-owner'] }
+
+      it 'does not report invalid owner' do
+        expect(runner.reports.join("\n")).not_to include('Invalid owner')
+      end
+    end
+
+    context 'without missing ref check' do
+      let(:extra_flags) { ['--no-check-missing-ref'] }
+
+      it 'does not report missing ref' do
+        expect(runner.reports.join("\n")).not_to include('No owner defined')
+      end
+    end
+
+    context 'without unrecognized line check' do
+      let(:extra_flags) { ['--no-check-unrecognized-line'] }
+
+      it 'does not report unrecognized line' do
+        expect(runner.reports.join("\n")).not_to include('Unrecognized line')
+      end
+    end
+
+    context 'without useless pattern check' do
+      let(:extra_flags) { ['--no-check-useless-pattern'] }
+
+      it 'does not report useless pattern' do
+        expect(runner.reports.join("\n")).not_to include('Useless patterns')
+      end
     end
   end
 end


### PR DESCRIPTION
This allow the caller to select which checks to run.
This can be useful if some of the checks are not useful for a particular user.

As by the help output:
```
➜  codeowners-checker git:(check-disable) ./bin/codeowners-checker -h check
Usage:
  codeowners-checker check REPO

Options:
      [--from=FROM]                                                
                                                                   # Default: origin/master
      [--to=TO]                                                    
                                                                   # Default: HEAD
  -i, [--interactive], [--no-interactive]                          
                                                                   # Default: true
  -v, [--validateowners], [--no-validateowners]                    
                                                                   # Default: true
  -c, [--autocommit], [--no-autocommit]                            
      [--check-unrecognized-line], [--no-check-unrecognized-line]  
                                                                   # Default: true
      [--check-useless-pattern], [--no-check-useless-pattern]      
                                                                   # Default: true
      [--check-missing-ref], [--no-check-missing-ref]              
                                                                   # Default: true
      [--check-invalid-owner], [--no-check-invalid-owner]          
                                                                   # Default: true

Checks .github/CODEOWNERS consistency
```

The flags that have been introduced are the `--check-*` and `--no-check-*` that enable/disable specific checks.
The way Thor works is a little bit confusing to me because it adds the true flags as well, even though they are set to be true by default, so that is a little bit confusing, if you have any suggestion on how to make it better, please say so. (There are a few issues opened on Thor repo about that, by the way)

This also works as temporary workaround for #82 since some checks are not taking into consideration the diff between `--from` and `--to` (for now, the only one that changes the behavior based on those flags is the missing ref check). So by introducing these flags, we can check only things changed in the pr by running `codeowners-checker --no-check-unrecognized-line --no-check-useless-pattern --no-check-invalid-owner` which will check only missing refs, which is the only check that is "diff-aware" for now.

Also, it is worth mentioning that as it stands right now, the missing ref check does not take into consideration diffs in the `CODEOWNERS` file itself, so removing a line from codeowners can make a file unowned and will slip undetected by the check. We plan to update that behavior in the future to take that into consideration.

As we improve this tool, we'll probably make all files "diff-aware" and therefore the normal run will be good for reporting only changes caused by the PR and those flags will be here to enable selective checks. (Maybe we should add `only-check` flags as well, but with thor automatically adding the `no-` version as well makes everything weird, so I'd skip that for now)